### PR TITLE
broaden TDD classification gate trigger surface beyond .ts/.tsx

### DIFF
--- a/init-pipeline/SKILL.md
+++ b/init-pipeline/SKILL.md
@@ -24,30 +24,45 @@ This blocks dangerous git commands (`git push`, `git reset --hard`, `git clean -
 
 ### 2. TDD classification gate (Claude Code hook)
 
-Create `.claude/hooks/enforce-classification.sh` and make it executable. This blocks Write/Edit to `.ts`/`.tsx` implementation files unless the `/execute` Step 3 classification gate has been passed.
+Create `.claude/hooks/enforce-classification.sh` and make it executable. This blocks Write/Edit to implementation files unless the `/execute` Step 3 classification gate has been passed.
 
-The hook checks for either `.claude/.tdd-active` (TDD invoked) or `.claude/.tdd-skipped` (visual frontend, explicitly opted out). No path checking — it enforces "did you go through the gate?"
+The hook checks for either `.claude/.tdd-active` (TDD invoked) or `.claude/.tdd-skipped` (visual frontend, explicitly opted out). No path checking beyond the trigger surface — it enforces "did you go through the gate?"
+
+**Install-time: ask which file patterns constitute implementation code.** Before scaffolding the hook, present the user with the default include list and ask:
+
+> "The TDD classification gate fires on Write/Edit of files matching a pattern list. Default: `*.ts, *.tsx, *.astro, *.py, *.go, *.rb, *.java, *.rs, *.js, *.jsx, *.vue, *.svelte`. Over-gating is fine — classification is a one-line answer. Accept the default, or customize for this project?"
+
+Use the confirmed list (default or customized) to populate the `IMPL_PATTERNS` array in the hook body below. Over-gating is acceptable — the cost of an extra classification prompt is lower than the cost of silent under-fire on a polyglot project. If `/init-pipeline` is running non-interactively (auto-invoked by `/execute` Step 0), accept the default list and record that fact in the hook body via a leading comment.
+
+**Skip logic stays extension-agnostic.** Tests, type declarations, and config files are detected by path substring (`*test*`, `*spec*`, `.d.ts`, `.config.*`) rather than per-language expansion.
 
 ```bash
 #!/bin/bash
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-# Only enforce for TypeScript files (not test files, not type declarations, not config)
-if [[ "$FILE_PATH" == *.ts || "$FILE_PATH" == *.tsx ]]; then
-  # Skip test files and type declarations
-  if [[ "$FILE_PATH" == *test* || "$FILE_PATH" == *spec* || "$FILE_PATH" == *.d.ts ]]; then
-    exit 0
-  fi
-  # Skip config files (drizzle.config, vite.config, etc.)
-  if [[ "$FILE_PATH" == *.config.* ]]; then
-    exit 0
-  fi
-  # Check for classification markers
-  if [ ! -f "$CLAUDE_PROJECT_DIR/.claude/.tdd-active" ] && [ ! -f "$CLAUDE_PROJECT_DIR/.claude/.tdd-skipped" ]; then
-    echo '{"decision":"block","reason":"BLOCKED: classify work in /execute Step 3 before writing implementation files. Either invoke /tdd (backend/behavior-heavy) or create .claude/.tdd-skipped (visual frontend)."}' >&2
-    exit 2
-  fi
+# Implementation patterns — populated at install time from the user's answer to
+# the /init-pipeline trigger-surface question. Over-gating is intended.
+IMPL_PATTERNS=("*.ts" "*.tsx" "*.astro" "*.py" "*.go" "*.rb" "*.java" "*.rs" "*.js" "*.jsx" "*.vue" "*.svelte")
+
+MATCHED=0
+for pattern in "${IMPL_PATTERNS[@]}"; do
+  if [[ "$FILE_PATH" == $pattern ]]; then MATCHED=1; break; fi
+done
+if [ $MATCHED -eq 0 ]; then exit 0; fi
+
+# Skip test files and type declarations (extension-agnostic)
+if [[ "$FILE_PATH" == *test* || "$FILE_PATH" == *spec* || "$FILE_PATH" == *.d.ts ]]; then
+  exit 0
+fi
+# Skip config files (drizzle.config, vite.config, etc.)
+if [[ "$FILE_PATH" == *.config.* ]]; then
+  exit 0
+fi
+# Check for classification markers
+if [ ! -f "$CLAUDE_PROJECT_DIR/.claude/.tdd-active" ] && [ ! -f "$CLAUDE_PROJECT_DIR/.claude/.tdd-skipped" ]; then
+  echo '{"decision":"block","reason":"BLOCKED: classify work in /execute Step 3 before writing implementation files. Either invoke /tdd (backend/behavior-heavy) or create .claude/.tdd-skipped (visual frontend)."}' >&2
+  exit 2
 fi
 exit 0
 ```
@@ -242,6 +257,7 @@ Append these lines if not already present:
 Before considering setup complete, check:
 
 - [ ] `.claude/hooks/enforce-classification.sh` exists and is executable
+- [ ] Hook's `IMPL_PATTERNS` array matches the project's implementation surface as confirmed during install (default list or customized answer)
 - [ ] `.claude/hooks/block-dangerous-git.sh` exists and is executable
 - [ ] `.claude/settings.json` has both PreToolUse hooks configured
 - [ ] If quality gate accepted: `.claude/hooks/quality-gate.sh` exists, is executable, and PostToolUse hook is in settings

--- a/init-pipeline/SKILL.md
+++ b/init-pipeline/SKILL.md
@@ -30,7 +30,7 @@ The hook checks for either `.claude/.tdd-active` (TDD invoked) or `.claude/.tdd-
 
 **Install-time: ask which file patterns constitute implementation code.** Before scaffolding the hook, present the user with the default include list and ask:
 
-> "The TDD classification gate fires on Write/Edit of files matching a pattern list. Default: `*.ts, *.tsx, *.astro, *.py, *.go, *.rb, *.java, *.rs, *.js, *.jsx, *.vue, *.svelte`. Over-gating is fine — classification is a one-line answer. Accept the default, or customize for this project?"
+> "The TDD classification gate fires on Write/Edit of files matching a pattern list. Default: `*.ts, *.tsx, *.astro, *.py, *.go, *.rb, *.java, *.rs, *.js, *.jsx, *.vue, *.svelte`. Over-gating is acceptable — classification is a quick decision at the top of /execute, though backend/behavior-heavy matches will trigger a full /tdd cycle. Accept the default, or customize for this project?"
 
 Use the confirmed list (default or customized) to populate the `IMPL_PATTERNS` array in the hook body below. Over-gating is acceptable — the cost of an extra classification prompt is lower than the cost of silent under-fire on a polyglot project. If `/init-pipeline` is running non-interactively (auto-invoked by `/execute` Step 0), accept the default list and record that fact in the hook body via a leading comment.
 


### PR DESCRIPTION
## Summary

The `/init-pipeline` TDD classification gate's hook body hard-coded `*.ts`/`*.tsx`, silently under-firing on polyglot and non-TypeScript projects. This change replaces the hard-coded extension check with an `IMPL_PATTERNS` array populated from a single install-time question (generous multi-language default), keeps skip logic extension-agnostic, and adds a verification item so the configured trigger surface is auditable.

## PRD

Closes #10

## Slices

No slice decomposition — issue #10 is an `/improve-pipeline` proposal with a narrow single-PR change set specified in its Mediator Verdict.

## Key Decisions

- Scope kept strictly to `init-pipeline/SKILL.md` per the issue's Non-Goals and Repo-Wide Context. `execute/SKILL.md`, `CLAUDE.md`, `tdd/SKILL.md`, and `SYSTEM-OVERVIEW.md` were flagged as unaffected and left untouched — stale prose references to ".ts files" in those surfaces are out of scope for this change.
- Pattern array is embedded inline in the hook body (not externalized to `.claude/tdd-gate.json`) per the Non-Goals section.
- `.tdd-active` / `.tdd-skipped` marker contract, hook's PreToolUse position, and `/execute` Step 0 auto-invocation all preserved.
- Over-gating accepted as the intended default — the user explicitly confirmed this in the shape session referenced by the issue.