### PR TITLE
add(compound, research): rule-scope on solution-doc template + consumer scope check

### DIFF
--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -119,7 +119,7 @@ Determine the category for filing. Use the most specific category that fits:
 
 Create the document in `docs/solutions/<category>/`. Use the template below.
 
-**Before writing the Root Cause section**, apply two tests. First: was the outcome a predictable consequence of the decision, or did it depend on conditions that weren't available to reason about at decision time? If unpredictable from the decision, the lesson belongs in Context (what you now know about the environment), not Prevention (what to do differently next time). Second: under what conditions would this lesson mislead a future agent? If you can't name a condition that would make the lesson wrong, tighten it until it's falsifiable or drop it.
+**Before writing the Root Cause section**, apply two tests. First: was the outcome a predictable consequence of the decision, or did it depend on conditions that weren't available to reason about at decision time? If unpredictable from the decision, the lesson belongs in Context (what you now know about the environment), not Prevention (what to do differently next time). Second: under what conditions would this lesson mislead a future agent? If you can't name a condition that would make the lesson wrong, tighten it until it's falsifiable or drop it. For Pattern and Structure lessons, record the answer in the Rule Scope section of the template so future `/research` consumers can pattern-match their own work's shape against the preconditions without re-deriving them from prose.
 
 **Ensure the directory exists:**
 ```bash
@@ -166,6 +166,16 @@ volatility: evergreen | stable | volatile
 
 - **Level:** Event / Pattern / Structure
 - **Feedback loop or delay:** [If applicable, what reinforcing loop, balancing loop, missing feedback, or delayed effect made this likely?]
+
+## Rule Scope
+
+*Required for Pattern and Structure lessons. Optional for Event lessons — include only when the event's Solution embeds a transferable rule.*
+
+[State the structural conditions under which the Solution's recommendation is correct, so a future `/research` consumer can pattern-match against their own work's shape without re-deriving the preconditions from prose. Be specific about shape, not just keywords — a 2-step agent loop with a terminal forced tool is a different shape from a 3-step loop where the same tool is non-terminal, even though both mention the same tool name. Note where the rule inverts if the conditions differ, and cross-reference sibling docs that cover the inverted or adjacent shape.]
+
+- **Applies when:** [Structural preconditions — e.g., "the forced tool is terminal in the agent loop", "the callback replaces rather than merges the collection", "the component is a client component rendered inside an RSC boundary"]
+- **Inverts or does not apply when:** [The shapes where following this recommendation would produce the opposite of the intended outcome, or simply not help — e.g., "for N+1-step loops where the tool is non-terminal, the `stopWhen` list must exclude it; see `<sibling-doc>`"]
+- **Sibling docs:** [Links to `docs/solutions/` entries covering adjacent or inverted shapes, if any exist]
 
 ## Solution
 

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -141,6 +141,8 @@ grep -rl "relevant-keyword" docs/solutions/ 2>/dev/null
 
 If relevant solutions exist, read them and incorporate their lessons. Note which past pitfalls or patterns apply. This is the compounding benefit — past work makes future research faster and more accurate.
 
+**Scope check before transfer.** When a loaded solution doesn't state explicit scope or preconditions (the `Rule Scope` section added by `/compound`), or when its stated scope doesn't match the current work's structural shape, re-derive the recommendation from first principles rather than transferring it. A rule correct for a 2-step agent loop with a terminal forced tool can invert for a 3-step loop where the same tool is non-terminal — keyword match is not shape match. Verify the shape, don't skip the check.
+
 **Staleness check:** When reading a `docs/solutions/` file, check its `volatility` YAML field and `date`. If `volatile` and older than 90 days, or if the Shelf Life condition appears to have been met, note it as potentially stale before incorporating its lessons. Flag stale docs to the user — they should be updated or deleted.
 
 ### Phase 4: Research


### PR DESCRIPTION
## Summary

Adds a `## Rule Scope` section to `/compound`'s solution-document template (required for Pattern/Structure lessons, optional for Event lessons) and a matching consumer-side scope check to `/research` Phase 3 so rules cited from `docs/solutions/` can't be transferred across incompatible structural shapes without re-derivation.

## PRD

Closes #21

## Key Decisions

- Placed `Rule Scope` between `Learning Level` and `Solution` so the Learning-Level classification gates whether the field is required, and so the scope is visible *before* the Solution it governs.
- Three-bullet shape: `Applies when` / `Inverts or does not apply when` / `Sibling docs`. Keeps the field structurally falsifiable (the Mediator Verdict's core requirement) without forcing ceremony on simple cases.
- Kept `/research` Phase 3 change to a single paragraph, advisory only — upgrading to a gate is reserved for recurrence evidence per the issue's "What evidence would justify revisiting" section.
- Held the proposal's non-goals: no new skill, no new gate, no retroactive audit mandate, no changes to `/write-a-prd`, `/pre-merge`, or `docs/skill-anatomy.md`.