### PR TITLE
add(research): filed-issue freshness rule (closes #27)

### DIFF
--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -193,6 +193,8 @@ Research the codebase and relevant technologies. Use sub-agents in parallel when
 1. **Explore relevant existing code** — What patterns exist? What integration points are available? What constraints does the current architecture impose?
 2. **Fetch current documentation** — If Context7 MCP is available, use `resolve_library` and `get_library_docs` for the specific installed version. If not, use web search targeting official docs for the installed version — never the "latest" version unless it matches what's installed. Also check for `llms.txt` at the library's documentation site.
 3. **Verify every API reference** — Do NOT trust training data for any framework API call. Every API method, import path, file convention, or function signature in your research output must trace back to either: (a) the installed version's official documentation, (b) a verified web search result, or (c) existing working code in the current codebase. If you cannot verify an API reference, mark it explicitly: "⚠ UNVERIFIED — could not confirm this API exists in [version]."
+
+   **Calibrate filed-issue evidence.** When a citation originates from a filed GitHub issue (or equivalent bug tracker), verify (a) the issue state (open/closed), (b) whether a fix has shipped and in which released version, and (c) whether the current official docs for the installed version contradict the issue. Canonical current docs outrank filed issues when they conflict; closed or resolved issues are not evidence of current state unless you explicitly read the resolution. A filed issue is a hypothesis about a point in time, not a verdict about now — the cheapest counterfactual is to read the current docs page for the feature the issue describes.
 4. **Evaluate each option against constraints** — Score each option against the constraints from Phase 2. Be explicit about which constraints each option satisfies or violates.
 
 For each option investigated, ask:
@@ -410,6 +412,9 @@ For each callback the feature implements:
 
 **⚠️ Partially verified (community source, or version not exactly matched):**
 - [Source title](URL) — [What was learned, caveat]
+
+**⚠️ Historical / resolved issue (was true when filed, not current state):**
+- [Source title](URL) — [What was once true, when it was resolved, and why it is retained here as context rather than evidence]
 
 **❓ Unverified (blog post, may be outdated, or no doc link found):**
 - [Source title](URL) — [What was learned, risk]


### PR DESCRIPTION
## Summary

Implements the Mediator verdict from issue #27: two narrow additions to `research/SKILL.md` that close the filed-issue-freshness gap without creating a new section or bleeding into adjacent skills.

**Why it matters:** the skill already tells researchers to distrust training data. It did not tell them to distrust point-in-time filed-issue snapshots, which are also stale but from a different source. A recent research run cited three 2025 issues as current state, reached a wrong compat conclusion, and was corrected only because the user pushed back. Making the freshness check explicit closes the loop inside the skill instead of depending on catch-on-review.

## Key changes

- **Phase 4 step 3** — inline bullet added under \"Verify every API reference.\" When a citation is a filed issue, verify (a) issue state, (b) whether a fix shipped and in which released version, and (c) whether current official docs contradict it. Canonical docs outrank filed issues when they conflict; closed issues are not evidence of current state unless you read the resolution.
- **Phase 5 Sources template** — new `⚠️ Historical / resolved issue` tier added alongside Verified / Partially verified / Unverified. Gives superseded-but-informative citations a place to land so they don't silently promote into \"Partially verified.\"

No other files touched. No changes to `qa/`, `triage-issue/`, `pre-merge/`, or `references/SYSTEM-OVERVIEW.md`. Phase 0's 30–60s budget is preserved — the check runs where the citation is written, not in the mandatory environment scan.

## Framing

Zeller *two-condition validation*: condition 1 (source exists, says X) was already encoded; condition 2 (X still holds today) was implicit. The new bullet makes condition 2 explicit for the evidence shape that broke here.

Meadows *information-flow leverage*: routing a freshness check to the researcher at evidence-gathering time is cheap, no new resources, high-leverage. The counterargument — *policy resistance* from heavyweight required sections — bounds the change to a single inline bullet rather than a new section that boilerplate could colonize.

## Test plan

- [ ] Next `/research` run that surfaces a filed GitHub issue exercises the new bullet — verify the citation shows issue state and fix-ship info before being treated as current evidence.
- [ ] Next `/research` run that cites a resolved issue as historical context uses the new Sources tier rather than filing it under \"Partially verified.\"

## Related

- Closes #27
- Cross-link: #15 (same theme — `/research` producing false precision about libraries — different failure mode, stays distinct)

## Note on issue paths

The filed issue's \"Recommended Changes\" table referenced \"skills/research/SKILL.md.\" The skill actually lives at repo-root `research/SKILL.md` — corrected in this PR. No behavior change; just a path-noun correction.