### PR TITLE
remove(execute, pre-merge, system-overview): hardcoded base-branch defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.9.0 — Multi-slice branching defaults: subtractive fix to `/execute`, `/pre-merge`, `SYSTEM-OVERVIEW.md`
+
+Closes #25. Removes the hardcoded base-branch prescriptions across three pipeline artifacts so multi-slice PRDs with `Consumes from #N` runtime dependencies can stack PRs (Hammant Ch. 13: multiple PRs per story) without `/execute`'s stale-branch heuristic fighting them or `/pre-merge`'s diff step targeting the wrong base.
+
+### Changes
+
+- **`/execute` Step 0** — softens "from the base branch" to "from the appropriate base." The appropriate base is the repo's base branch by default; for a slice with an unmerged `Consumes from #N` dependency, the appropriate base is that sibling slice's branch so the stacked PR can target the sibling's PR. Stale-branch suspicion gains an explicit exception for sibling slice branches named in the current task's `Consumes from #N` declaration.
+- **`/pre-merge` Phase 1** — replaces hardcoded `git diff main...HEAD` and `git log main..HEAD` with the same detected-base pattern `/help` already uses (`git symbolic-ref refs/remotes/origin/HEAD` with fallback through `main`/`master`/`prod`/`trunk`). Also relevant for this very repo, whose default branch is `prod` — the prior pattern reported zero-line diffs locally.
+- **`/pre-merge` Phase 2** — `gh pr create` now passes `--base "$BASE_BRANCH"` so slice PRs target the detected base (override for stacked-PR slices that target a sibling).
+- **`SYSTEM-OVERVIEW.md`** — softens the Branch isolation gate enhancement note (no longer says "from the base branch") and changes singular "Output: Commits on the feature branch" to "feature branch(es)" to acknowledge multi-slice work.
+
+### Motivation
+
+Issue #25 went through `/improve-pipeline` twice. The original verdict prescribed a four-option (A/B/C/D) branching-strategy decision step in `/prd-to-issues` plus propagation across four other artifacts — a five-row recommendation set, all additions. PR #30 then added the subtraction lens to `/improve-pipeline` after empirical evidence that 18 of 18 prior issues proposed additions and zero proposed removals. Re-running the dialectic with subtraction as a first-class outcome surfaced that the strongest CD/Hammant/Accelerate-supported pattern for inter-coupled slices is feature-hiding (a coupling/slicing concern already handled by `/prd-to-issues` Step 4 orthogonality test plus the `Consumes from #N` contract), and that the actual wins are removing the wrong defaults — not adding a strategy-decision ceremony. The verdict direction (Proceed narrowly) and the library analysis (CD / Hammant / Accelerate) are unchanged; only the prescription's shape changes. The full A/B/C/D taxonomy remains useful as pedagogy in #25's body for reviewers and future agents who need to think through multi-slice integration; the pipeline does not record it as a decision artifact. This shipping shape is itself a test of PR #30 — `/improve-pipeline` self-applying the lens it just gained.
+
 ## v1.8.0 — Install-shippable shared references + interaction rules across interview skills
 
 Two changes land together. The headline is a structural fix to the pack's install output so skills stop pointing the agent at files the CLI never ships. The second is an extension of the per-skill "One question per turn" blockquote — queued unreleased since the shape-skills block first landed — that adds single-select / multi-select / platform-tool guidance across nine interview-driven skills. The through-line: make the pack's behavior the same on the author's machine and on a user's a month after install.

--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -128,7 +128,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Key enhancement to /execute:** GSD's verification ladder. After tests pass, Ralph checks the actual outcomes — files exist, exports are real (not stubs), imports resolve, API endpoints respond, behavioral flows work. For slices touching schema, migrations, environment config, or new routes, a mandatory runtime startup check verifies that the dev database has the latest schema, the dev server boots from cold, and new routes load without 500 errors — tests that use in-memory databases are not sufficient. "All steps done" is NOT verification. For bug fixes, an additional gate classifies the fix as correction (removes the defect) or workaround (suppresses the failure), searches for structural siblings of the defect pattern, and confirms the corrupted state is no longer produced.
 
-**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the base branch. Otherwise, a plain `git checkout -b` from the base branch.
+**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the appropriate base. Otherwise, a plain `git checkout -b` from the appropriate base. The default is the repo's base branch; for a slice with an unmerged `Consumes from #N` dependency that produces symbols the new slice imports, the appropriate base is that sibling slice's branch (Hammant *Trunk-Based Development* Ch. 13 — multiple PRs per story).
 
 **Key enhancement to /execute:** Now consults `docs/solutions/` and the research archive entry for this feature before implementation, so past lessons and technical decisions don't need re-discovery each iteration.
 
@@ -140,7 +140,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Plateau detection (second circuit breaker):** The repeated-failure rule above is a circuit breaker on the *error* signal. A second circuit breaker trips on the *progress* signal. Borrowing Shape Up's Hill Chart vocabulary, each AFK iteration should move the active slice uphill (resolving unknowns) or downhill (executing). An iteration counts as progress only if at least one unmet acceptance criterion, failing check, or unresolved unknown transitions to resolved. Code churn without any such transition is a stationary dot. If two consecutive iterations on the same slice produce stationary dots, Ralph should stop and escalate — same bounded-retry shape as the failure rule. Hysteresis: a single recovering iteration (one resolved unknown or newly-passing check) resets the stationary counter.
 
-**Output:** Commits on the feature branch. GitHub issues closed as completed.
+**Output:** Commits on the feature branch(es). GitHub issues closed as completed.
 
 **Time:** 5-15 min active (launching + reviewing), 30-120 min AFK.
 

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -128,7 +128,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Key enhancement to /execute:** GSD's verification ladder. After tests pass, Ralph checks the actual outcomes — files exist, exports are real (not stubs), imports resolve, API endpoints respond, behavioral flows work. For slices touching schema, migrations, environment config, or new routes, a mandatory runtime startup check verifies that the dev database has the latest schema, the dev server boots from cold, and new routes load without 500 errors — tests that use in-memory databases are not sufficient. "All steps done" is NOT verification. For bug fixes, an additional gate classifies the fix as correction (removes the defect) or workaround (suppresses the failure), searches for structural siblings of the defect pattern, and confirms the corrupted state is no longer produced.
 
-**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the base branch. Otherwise, a plain `git checkout -b` from the base branch.
+**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the appropriate base. Otherwise, a plain `git checkout -b` from the appropriate base. The default is the repo's base branch; for a slice with an unmerged `Consumes from #N` dependency that produces symbols the new slice imports, the appropriate base is that sibling slice's branch (Hammant *Trunk-Based Development* Ch. 13 — multiple PRs per story).
 
 **Key enhancement to /execute:** Now consults `docs/solutions/` and the research archive entry for this feature before implementation, so past lessons and technical decisions don't need re-discovery each iteration.
 
@@ -140,7 +140,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Plateau detection (second circuit breaker):** The repeated-failure rule above is a circuit breaker on the *error* signal. A second circuit breaker trips on the *progress* signal. Borrowing Shape Up's Hill Chart vocabulary, each AFK iteration should move the active slice uphill (resolving unknowns) or downhill (executing). An iteration counts as progress only if at least one unmet acceptance criterion, failing check, or unresolved unknown transitions to resolved. Code churn without any such transition is a stationary dot. If two consecutive iterations on the same slice produce stationary dots, Ralph should stop and escalate — same bounded-retry shape as the failure rule. Hysteresis: a single recovering iteration (one resolved unknown or newly-passing check) resets the stationary counter.
 
-**Output:** Commits on the feature branch. GitHub issues closed as completed.
+**Output:** Commits on the feature branch(es). GitHub issues closed as completed.
 
 **Time:** 5-15 min active (launching + reviewing), 30-120 min AFK.
 

--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -37,7 +37,7 @@ Do not use it to replace `/shape`, `/research`, or `/write-a-prd` when the probl
 - **Worktrunk** (if `wt` is available): `wt switch --create <branch-name>` — creates a new worktree + branch from the appropriate base and switches to it, giving full filesystem isolation. Use the `/worktrunk` skill for guidance.
 - **Plain git**: `git checkout <base> && git checkout -b <branch-name>` — creates a new branch from the appropriate base in the current working directory.
 
-The **appropriate base** is the repo's base branch (`main`, `prod`, `master`) by default. For a slice with an unmerged `Consumes from #N` dependency that produces symbols this slice imports, branch from that sibling slice's branch instead so the stacked PR can target the sibling's PR (Hammant *Trunk-Based Development* Ch. 13: multiple PRs per story; the sibling's PR must still merge to the base branch within 2 days).
+The **appropriate base** is the repo's own base branch by default — whatever the repo declares (`git symbolic-ref refs/remotes/origin/HEAD`). Do not assume `main`. For a slice with an unmerged `Consumes from #N` dependency that produces symbols this slice imports, branch from that sibling slice's branch instead so the stacked PR can target the sibling's PR (Hammant *Trunk-Based Development* Ch. 13: multiple PRs per story; the sibling's PR must still merge to the repo's base branch within 2 days).
 
 Derive the branch name from the task: e.g., `issue-5-landing-page`, `landing-page`, or the issue slug. Do not reuse branch names from previous work.
 

--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -30,12 +30,14 @@ Do not use it to replace `/shape`, `/research`, or `/write-a-prd` when the probl
 
 1. Check the current branch: `git branch --show-current`
 2. If the current branch is the base branch (e.g., `main`, `prod`, `master`), create a new feature branch for this task.
-3. If the current branch is a **different feature branch** (not the base branch and not a branch named for this task), you are on a stale branch from previous work. Do not commit new work here.
+3. If the current branch is a **different feature branch** (not the base branch and not a branch named for this task), you are on a stale branch from previous work. Do not commit new work here. **Exception:** if the current branch is a sibling slice branch named in this task's `Consumes from #N` declaration, you are intentionally about to fork from it for a stacked-PR slice — proceed.
 
 **To create an isolated branch**, use one of these approaches (in order of preference):
 
-- **Worktrunk** (if `wt` is available): `wt switch --create <branch-name>` — creates a new worktree + branch from the base branch and switches to it, giving full filesystem isolation. Use the `/worktrunk` skill for guidance.
-- **Plain git**: `git checkout <base-branch> && git checkout -b <branch-name>` — creates a new branch from the base branch in the current working directory.
+- **Worktrunk** (if `wt` is available): `wt switch --create <branch-name>` — creates a new worktree + branch from the appropriate base and switches to it, giving full filesystem isolation. Use the `/worktrunk` skill for guidance.
+- **Plain git**: `git checkout <base> && git checkout -b <branch-name>` — creates a new branch from the appropriate base in the current working directory.
+
+The **appropriate base** is the repo's base branch (`main`, `prod`, `master`) by default. For a slice with an unmerged `Consumes from #N` dependency that produces symbols this slice imports, branch from that sibling slice's branch instead so the stacked PR can target the sibling's PR (Hammant *Trunk-Based Development* Ch. 13: multiple PRs per story; the sibling's PR must still merge to the base branch within 2 days).
 
 Derive the branch name from the task: e.g., `issue-5-landing-page`, `landing-page`, or the issue slug. Do not reuse branch names from previous work.
 

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -128,7 +128,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Key enhancement to /execute:** GSD's verification ladder. After tests pass, Ralph checks the actual outcomes — files exist, exports are real (not stubs), imports resolve, API endpoints respond, behavioral flows work. For slices touching schema, migrations, environment config, or new routes, a mandatory runtime startup check verifies that the dev database has the latest schema, the dev server boots from cold, and new routes load without 500 errors — tests that use in-memory databases are not sufficient. "All steps done" is NOT verification. For bug fixes, an additional gate classifies the fix as correction (removes the defect) or workaround (suppresses the failure), searches for structural siblings of the defect pattern, and confirms the corrupted state is no longer produced.
 
-**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the base branch. Otherwise, a plain `git checkout -b` from the base branch.
+**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the appropriate base. Otherwise, a plain `git checkout -b` from the appropriate base. The default is the repo's base branch; for a slice with an unmerged `Consumes from #N` dependency that produces symbols the new slice imports, the appropriate base is that sibling slice's branch (Hammant *Trunk-Based Development* Ch. 13 — multiple PRs per story).
 
 **Key enhancement to /execute:** Now consults `docs/solutions/` and the research archive entry for this feature before implementation, so past lessons and technical decisions don't need re-discovery each iteration.
 
@@ -140,7 +140,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Plateau detection (second circuit breaker):** The repeated-failure rule above is a circuit breaker on the *error* signal. A second circuit breaker trips on the *progress* signal. Borrowing Shape Up's Hill Chart vocabulary, each AFK iteration should move the active slice uphill (resolving unknowns) or downhill (executing). An iteration counts as progress only if at least one unmet acceptance criterion, failing check, or unresolved unknown transitions to resolved. Code churn without any such transition is a stationary dot. If two consecutive iterations on the same slice produce stationary dots, Ralph should stop and escalate — same bounded-retry shape as the failure rule. Hysteresis: a single recovering iteration (one resolved unknown or newly-passing check) resets the stationary counter.
 
-**Output:** Commits on the feature branch. GitHub issues closed as completed.
+**Output:** Commits on the feature branch(es). GitHub issues closed as completed.
 
 **Time:** 5-15 min active (launching + reviewing), 30-120 min AFK.
 

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -128,7 +128,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Key enhancement to /execute:** GSD's verification ladder. After tests pass, Ralph checks the actual outcomes — files exist, exports are real (not stubs), imports resolve, API endpoints respond, behavioral flows work. For slices touching schema, migrations, environment config, or new routes, a mandatory runtime startup check verifies that the dev database has the latest schema, the dev server boots from cold, and new routes load without 500 errors — tests that use in-memory databases are not sufficient. "All steps done" is NOT verification. For bug fixes, an additional gate classifies the fix as correction (removes the defect) or workaround (suppresses the failure), searches for structural siblings of the defect pattern, and confirms the corrupted state is no longer produced.
 
-**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the base branch. Otherwise, a plain `git checkout -b` from the base branch.
+**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the appropriate base. Otherwise, a plain `git checkout -b` from the appropriate base. The default is the repo's base branch; for a slice with an unmerged `Consumes from #N` dependency that produces symbols the new slice imports, the appropriate base is that sibling slice's branch (Hammant *Trunk-Based Development* Ch. 13 — multiple PRs per story).
 
 **Key enhancement to /execute:** Now consults `docs/solutions/` and the research archive entry for this feature before implementation, so past lessons and technical decisions don't need re-discovery each iteration.
 
@@ -140,7 +140,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Plateau detection (second circuit breaker):** The repeated-failure rule above is a circuit breaker on the *error* signal. A second circuit breaker trips on the *progress* signal. Borrowing Shape Up's Hill Chart vocabulary, each AFK iteration should move the active slice uphill (resolving unknowns) or downhill (executing). An iteration counts as progress only if at least one unmet acceptance criterion, failing check, or unresolved unknown transitions to resolved. Code churn without any such transition is a stationary dot. If two consecutive iterations on the same slice produce stationary dots, Ralph should stop and escalate — same bounded-retry shape as the failure rule. Hysteresis: a single recovering iteration (one resolved unknown or newly-passing check) resets the stationary counter.
 
-**Output:** Commits on the feature branch. GitHub issues closed as completed.
+**Output:** Commits on the feature branch(es). GitHub issues closed as completed.
 
 **Time:** 5-15 min active (launching + reviewing), 30-120 min AFK.
 

--- a/pre-merge/SKILL.md
+++ b/pre-merge/SKILL.md
@@ -37,12 +37,18 @@ Do not use it as a substitute for implementation verification, QA intake, or ref
    ```
    Parse boundary maps (Produces/Consumes sections) from each slice issue body.
 
-3. **Assess the diff:**
+3. **Detect the base branch and assess the diff:**
    ```bash
-   git diff main...HEAD --stat
-   git log --oneline main..HEAD
+   BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's@^origin/@@')
+   if [ -z "$BASE_BRANCH" ]; then
+     for candidate in main master prod trunk; do
+       if git rev-parse --verify "$candidate" >/dev/null 2>&1; then BASE_BRANCH=$candidate; break; fi
+     done
+   fi
+   git diff "$BASE_BRANCH...HEAD" --stat
+   git log --oneline "$BASE_BRANCH..HEAD"
    ```
-   If no diff from main, tell the user there's nothing to review and stop.
+   For a stacked-PR slice, override `$BASE_BRANCH` with the sibling slice's branch name (the upstream the PR will target). If no diff from the base, tell the user there's nothing to review and stop. Do not hardcode `main` — Skill Kit's own repo uses `prod`, and many others use `develop`, `trunk`, or a team-specific name.
 
 ### Phase 2: Create the PR
 
@@ -51,7 +57,7 @@ Do not use it as a substitute for implementation verification, QA intake, or ref
    gh pr list --head $(git branch --show-current) --json number,url
    ```
 
-2. **Create or update the PR.** Use `gh pr create` or `gh pr edit`.
+2. **Create or update the PR.** Use `gh pr create --base "$BASE_BRANCH"` (override `--base` for stacked-PR slices to the sibling slice's branch) or `gh pr edit`.
 
 **PR body template (when PRD exists):**
 

--- a/pre-merge/SKILL.md
+++ b/pre-merge/SKILL.md
@@ -41,7 +41,7 @@ Do not use it as a substitute for implementation verification, QA intake, or ref
    ```bash
    BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's@^origin/@@')
    if [ -z "$BASE_BRANCH" ]; then
-     for candidate in main master prod trunk; do
+     for candidate in main master prod develop trunk; do
        if git rev-parse --verify "$candidate" >/dev/null 2>&1; then BASE_BRANCH=$candidate; break; fi
      done
    fi

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -128,7 +128,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Key enhancement to /execute:** GSD's verification ladder. After tests pass, Ralph checks the actual outcomes — files exist, exports are real (not stubs), imports resolve, API endpoints respond, behavioral flows work. For slices touching schema, migrations, environment config, or new routes, a mandatory runtime startup check verifies that the dev database has the latest schema, the dev server boots from cold, and new routes load without 500 errors — tests that use in-memory databases are not sufficient. "All steps done" is NOT verification. For bug fixes, an additional gate classifies the fix as correction (removes the defect) or workaround (suppresses the failure), searches for structural siblings of the defect pattern, and confirms the corrupted state is no longer produced.
 
-**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the base branch. Otherwise, a plain `git checkout -b` from the base branch.
+**Key enhancement to /execute:** Branch isolation gate. Before starting any implementation, `/execute` verifies the current branch is appropriate — not a stale feature branch from previous work. If worktrunk (`wt`) is available, it uses `wt switch --create` to create an isolated worktree + branch from the appropriate base. Otherwise, a plain `git checkout -b` from the appropriate base. The default is the repo's base branch; for a slice with an unmerged `Consumes from #N` dependency that produces symbols the new slice imports, the appropriate base is that sibling slice's branch (Hammant *Trunk-Based Development* Ch. 13 — multiple PRs per story).
 
 **Key enhancement to /execute:** Now consults `docs/solutions/` and the research archive entry for this feature before implementation, so past lessons and technical decisions don't need re-discovery each iteration.
 
@@ -140,7 +140,7 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Plateau detection (second circuit breaker):** The repeated-failure rule above is a circuit breaker on the *error* signal. A second circuit breaker trips on the *progress* signal. Borrowing Shape Up's Hill Chart vocabulary, each AFK iteration should move the active slice uphill (resolving unknowns) or downhill (executing). An iteration counts as progress only if at least one unmet acceptance criterion, failing check, or unresolved unknown transitions to resolved. Code churn without any such transition is a stationary dot. If two consecutive iterations on the same slice produce stationary dots, Ralph should stop and escalate — same bounded-retry shape as the failure rule. Hysteresis: a single recovering iteration (one resolved unknown or newly-passing check) resets the stationary counter.
 
-**Output:** Commits on the feature branch. GitHub issues closed as completed.
+**Output:** Commits on the feature branch(es). GitHub issues closed as completed.
 
 **Time:** 5-15 min active (launching + reviewing), 30-120 min AFK.
 


### PR DESCRIPTION
## Summary

- Closes #25 via the subtractive shape from PR #30's lens. Re-running `/improve-pipeline` on #25 with subtraction as a first-class outcome surfaced that the actual wins are removing wrong defaults — not adding a four-option branching-strategy decision step in `/prd-to-issues`.
- Verdict direction (Proceed narrowly) and library analysis (CD / Hammant / Accelerate) unchanged from #25. Only the prescription's shape changes: from a 5-row, addition-heavy recommendation to 4 rows, all `remove`/`modify`/`add`. `/prd-to-issues` is deliberately not touched.
- This shipping shape is itself a test of PR #30 — `/improve-pipeline` self-applying the lens it just gained.

## Changes

- **`/execute` Step 0** — softens "from the base branch" to "from the appropriate base"; adds an explicit exception to the stale-branch rule for sibling slice branches named in this task's `Consumes from #N` declaration so stacked-PR setup is not misclassified as stale work.
- **`/pre-merge` Phase 1** — replaces hardcoded `git diff main...HEAD` and `git log main..HEAD` with the same detected-base pattern `/help` already uses (`git symbolic-ref refs/remotes/origin/HEAD` with fallback). This was already a latent bug on this very repo, whose default branch is `prod` — the prior pattern reported zero-line diffs locally.
- **`/pre-merge` Phase 2** — `gh pr create --base "$BASE_BRANCH"` so slice PRs target the detected base; documented override path for stacked-PR slices that target a sibling.
- **`SYSTEM-OVERVIEW.md` L131, L143** — softens the Branch isolation gate enhancement note and changes singular "Output: Commits on the feature branch" to "feature branch(es)."
- **`CHANGELOG.md`** — v1.9.0 entry tying motivation back to PR #30.

Synced bundled copies of `SYSTEM-OVERVIEW.md` in `help/`, `correct-course/`, `setup-ralph-loop/`, `improve-pipeline/` via `scripts/sync-skill-references.sh`.

## Deliberately not changed

- **`/prd-to-issues`.** Its existing Step 4 orthogonality test plus the `Consumes from #N` contract already encode the coupling concern. Adding a record-and-justify "decide branching strategy" step would institutionalize ceremony for a question already asked elsewhere in the pipeline (Meadows: policy resistance).
- **No new "Multi-slice branching" subsection in `SYSTEM-OVERVIEW.md`.** The corrected single-branch framing plus the `Consumes from #N` contract is sufficient; the A/B/C/D pedagogy lives in #25's Mediator Verdict for reviewers and future agents who need it, not as canon to copy into every overview doc.

## Test plan

- [ ] Skim each of the four file edits and confirm the softening is the minimal coherent change (no new prescriptions added).
- [ ] Confirm `bash scripts/sync-skill-references.sh --check` passes (CI will also enforce this).
- [ ] Confirm CI's `check-skill-references`, `shellcheck`, and `script-tests` jobs pass.
- [ ] Mentally walk the `/execute` Step 0 flow for a stacked slice (B depends on A): verify rule #3 exception fires correctly when the user has checked out sibling-A before forking the new task branch.
- [ ] Mentally walk `/pre-merge` Phase 1 on this very repo: confirm `BASE_BRANCH` resolves to `prod` and the diff step now reports real changes instead of zero lines.
- [ ] Confirm the `--base "$BASE_BRANCH"` argument in `gh pr create` does not break the existing "no PRD given" path (Phase 2 should still work for trivial PRs).