### PR TITLE
add(pre-merge): Surgical Scope dimension for non-PRD scope drift

### DIFF
--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -314,7 +314,7 @@ Example — if the AC says "user can reset their password via email":
 - [ ] Go to /login → click "Forgot password" → enter test email → confirm reset email arrives → follow link → set new password → log in with new password
 
 After the generated steps, always include:
-- [ ] Scope matches what was asked — no unasked-for additions, no missing pieces
+- [ ] Scope matches what was asked — no unasked-for additions, no missing pieces (this is the in-flight self-check; `/pre-merge`'s Surgical Scope dimension is the diff-time check that runs against the merged hunks)
 
 #### Ready for PR Review
 

--- a/pre-merge/SKILL.md
+++ b/pre-merge/SKILL.md
@@ -96,12 +96,12 @@ For non-trivial PRs, write a plain-language walkthrough: one paragraph of domain
 
 ### Phase 3: Architectural Review
 
-Consult `review-checklist.md` for the eight review dimensions and their violation patterns.
+Consult `review-checklist.md` for the review dimensions and their violation patterns.
 
-**Small diff** (< 200 changed lines, < 10 files): run all eight dimensions sequentially in the main agent.
+**Small diff** (< 200 changed lines, < 10 files): run all dimensions sequentially in the main agent.
 
 **Larger diff**: spawn two sub-agents in parallel:
-- **Sub-agent A (structural):** Deep Modules, Vertical Slice Integrity, State Discipline
+- **Sub-agent A (structural & scope):** Deep Modules, Vertical Slice Integrity, State Discipline, Surgical Scope
 - **Sub-agent B (contracts & quality):** Boundary Map Contracts, Test Quality, docs/solutions/ Adherence, Runtime Initialization, Fix Completeness
 
 Each sub-agent reads the full diff and its assigned dimensions from `review-checklist.md`, then returns findings in the three-tier severity format.
@@ -109,6 +109,8 @@ Each sub-agent reads the full diff and its assigned dimensions from `review-chec
 **Dimension 4 (Boundary Map Contracts) only runs if a PRD with slice issues was provided.** Without boundary maps, there are no contracts to verify.
 
 **Dimension 7 (Runtime Initialization) only runs if the diff includes schema files, migration files, environment config, or server startup code.** Without infrastructure changes, there is nothing to verify.
+
+**Surgical Scope runs on every diff.** Where Dimensions 4 and 5 check plan-vs-actual between slices (PRD-gated), Surgical Scope checks scope drift inside a single diff — drive-by reformatting, speculative additions, adjacent fixes — and applies whether or not the work went through `/prd-to-issues`. Findings under this dimension must cite the file path and hunk start line; "looks scope-creepy" is not a finding.
 
 **Dimension 6 (docs/solutions/ Adherence):** Search `docs/solutions/` for files whose `components` or `technologies` frontmatter overlaps with the changed code areas. If relevant solutions exist, check whether the implementation follows or consciously diverges from documented patterns.
 

--- a/pre-merge/review-checklist.md
+++ b/pre-merge/review-checklist.md
@@ -164,6 +164,31 @@ This is a **reconciliation test, not a gate.** Block only on unmapped Musts. War
 
 ---
 
+## 10. Surgical Scope
+
+**Principle:** Every changed hunk should trace to the stated task. A diff is the answer to a question; the question was not "what else could be improved?"
+
+Beck's *Two Hats* (TDD, refactoring-catalog): refactor and feature-add are two hats; never wear both at once, because if something breaks you can no longer attribute the cause. Hunt & Thomas (Pragmatic Programmer): each pass must have a single purpose — interleaving makes failures unattributable. The check belongs at review time because by then the diff exists and the question "does this hunk belong?" is concrete rather than aspirational.
+
+**Applies to every diff regardless of PRD status.** Boundary Map Contracts (Dimension 4) and Coverage Matrix Reconciliation (Dimension 5) check plan-vs-actual *between slices*, and only fire when a PRD exists. This dimension checks scope drift *inside a single diff* — drive-by reformatting, speculative additions, adjacent fixes that weren't asked for — and runs whether or not the work went through `/prd-to-issues`.
+
+**Stated task source.** The "stated task" is, in priority order: the slice issue body, the PRD issue body, the bug issue or QA report, or — for one-off branches — the commit messages and branch name. If no stated task can be reconstructed, note that and skip the dimension; do not synthesize one.
+
+**Violation patterns:**
+- **Drive-by reformatting** — quote-style swaps, whitespace rewrites, brace-style changes in files the task didn't require touching
+- **Speculative additions** — type hints, docstrings, new abstractions, or parameter additions that the task didn't ask for and no test demands
+- **Adjacent fix-while-here** — patching a different bug or removing unrelated dead code in the same diff (file separately, even if the adjacent fix is correct)
+- **Style drift** — applying a personal style preference (preferred quote, preferred test framework idiom, preferred import order) to existing code the task didn't require touching
+- **Refactor-and-feature interleave** — Beck's "shame, shame": a behavior change and a structural cleanup in the same commit, leaving any future bisect unable to attribute regressions
+
+**Verification procedure — cited hunks, not yes/no.** A finding under this dimension must cite the file path and the hunk's starting line. *"Looks scope-creepy"* is not a finding; *"`utils/format.ts:42–58` adds type hints and renames `result` to `formatted` — neither is mentioned in the task statement"* is. If the dimension produces zero findings on a non-trivial diff, that is a real outcome — do not invent findings to fill the section, and do not rubber-stamp it (Meadows policy resistance: required sections that go unused get filled with filler; the cited-hunk requirement is the mitigation).
+
+**Out of scope:** Whether the diff is architecturally good (that's Dimension 1). Whether the scope of the *task itself* was right (that's `/shape` and `/write-a-prd`). Whether unmapped commitments exist between slices (that's Dimension 5).
+
+**Review-cadence note.** This dimension was added without a triggering incident, on principle grounds (Beck, Hunt & Thomas). If after a reasonable sample of PRs it produces zero or one finding per PR on average, it is policy-resistant filler and should be removed rather than left as ceremony.
+
+---
+
 ## Severity Classification
 
 - **Observation:** A pattern worth noting but no principle is violated. The reviewer noticed something the developer should be aware of. Example: "The auth module now exports 7 functions — not a violation, but approaching the threshold where consolidation might help."


### PR DESCRIPTION
## Summary

`/pre-merge`'s eight-dimension review currently has no check for *"does every changed line belong to this task?"* on non-PRD branches. Boundary Map Contracts (Dimension 4) and Coverage Matrix Reconciliation (Dimension 5) catch plan-vs-actual drift *between slices*, but only fire when a PRD with slice issues was provided. For one-off branches, bug fixes, and any work that didn't go through `/prd-to-issues`, drive-by reformatting, speculative type hints, and "while I was here" refactors ride along through review unchallenged. The only defense is `/execute` Step 5's single bullet — *"Scope matches what was asked"* — which the user reads at the very end of execute, after the diff already exists.

This PR adds **Dimension 10: Surgical Scope** to `/pre-merge`'s review checklist. It asks, for every changed hunk: does this trace to the stated task? It runs on every diff regardless of PRD status, and findings must cite a file path plus hunk start line — *"looks scope-creepy"* is not a finding. The crispness comes from Beck's *Two Hats* in `/library kent-beck-tdd` (refactoring-catalog: *"Adding speculative changes during refactoring … makes it impossible to distinguish a broken refactoring from a broken feature addition"*) and Hunt & Thomas's *single-purpose pass* in `/library hunt-thomas-pragmatic-programmer` (coding-deliberateness: *"each pass must have a single purpose"*). The check belongs at review time because the diff is concrete by then; in-flight prevention is already covered by `/execute` Step 3 and main `CLAUDE.md`.

**Why it matters:** the asymmetry — PRD branches get scope discipline, one-off branches don't — is structural to the pipeline and not something the downstream repo can fix. With this change, Beck's Two Hats has an operational form on every PR rather than only on PRD-tracked ones.

## PRD

Closes #32

## Key Decisions

- **Numbering:** added as Dimension 10 in `pre-merge/review-checklist.md` (the existing checklist already has 9 dimensions; the SKILL.md prose previously said "eight" but the checklist file disagreed — out of scope to fix here, but worth a follow-up).
- **Sub-agent split:** placed in Sub-agent A (structural & scope) for the parallel-review path. The label widens from "structural" to "structural & scope" to accommodate it.
- **Cited-hunk requirement:** explicit mitigation for Meadows policy resistance (required sections that go unread get filled with filler). The dimension's verification procedure says findings must cite file:line, and zero findings is a real outcome — do not fabricate.
- **Review cadence:** the checklist entry includes a self-removal clause — if Surgical Scope produces zero or one finding per PR on average over a reasonable sample, it's policy-resistant filler and should be removed. The change is reversible by design because no incident motivated it.
- **`/execute` Step 5:** kept the existing scope bullet, added one parenthetical pointing at the new dimension. The in-flight self-check and the diff-time hard check stay coherent rather than duplicated.

## Test plan

- [ ] Read `pre-merge/review-checklist.md` Dimension 10 cold — does the violation list and verification procedure make the dimension actionable?
- [ ] Read `pre-merge/SKILL.md` Phase 3 — does the Sub-agent A widening and the new "Surgical Scope runs on every diff" callout read coherently next to the existing dimension callouts?
- [ ] Read `execute/SKILL.md` Step 5's scope bullet — is the cross-reference natural, or does it bloat the line?
- [ ] On the next non-PRD branch, run `/pre-merge` and confirm Sub-agent A executes Surgical Scope and produces at least one cited-hunk finding or a clean pass with the diff named.
- [ ] After ~5 PRs that hit Dimension 10, decide whether it's earning its place; remove if average findings per PR is ≤ 1 and the cited hunks are all non-substantive (whitespace-only, etc.).