### PR TITLE
add: opt-in spike-issue mode for /research output (#34)

### DIFF
--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -31,12 +31,12 @@ The pipeline order is the default path, not a prison. `Ralph` is the AFK executi
 **Artifact precedence.** When a skill consults multiple artifacts, resolve conflicts using this priority order:
 
 1. Working code in the repository (ground truth)
-2. The research archive entry for this feature (verified against installed versions at the `date` in its frontmatter)
+2. The research artifact for this feature — per-user archive entry or closed `research`-labeled spike issue, depending on the project's `research.storage` setting (verified against installed versions at the `date` in its frontmatter; storage location does not affect trust)
 3. `docs/solutions/` (compounded knowledge, possibly stale)
 4. Framework reference skills (general best practices)
 5. Model training data (least reliable for version-specific details)
 
-When the research archive entry and `docs/solutions/` disagree, the research entry wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
+When the research artifact and `docs/solutions/` disagree, the research artifact wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. The research artifact may live in either the per-user archive or as a closed `research`-labeled GitHub spike issue, depending on the project's `research.storage` setting; both carry equivalent authority because their bodies are produced by the same `/research` skill against the same Phase 0/1 verification. Storage location is a discoverability decision, not a trust decision. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
@@ -88,7 +88,12 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Staleness check:** When consulting `docs/solutions/`, `/research` checks the `volatility` field and date. Volatile solutions older than 90 days, or solutions whose Shelf Life condition appears met, are flagged as potentially stale before being incorporated.
 
-**Output:** One research file in the per-user archive at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness. Referenced in the PRD. Persists after ship — the archive is worktree- and branch-resilient and is not deleted during cleanup or backtracking.
+**Output:** One research artifact, location selected per project via `.claude/settings.json` `research.storage` (default `archive`):
+
+- **`archive`** — file at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Worktree- and branch-resilient. Right for solo / single-machine / private projects.
+- **`spike-issue`** — closed-on-creation GitHub issue in the same repo as the PRD, labeled `research`, with the same body and frontmatter the archive would carry. Reachable from any machine via `gh issue view`, citable from PRD/slice/PR/compound via `Refs #N`. Right for public, portfolio, OSS, transparency-themed, multi-contributor, or multi-machine projects.
+
+Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness regardless of storage location. Referenced in the PRD. Persists after ship — neither location is touched during cleanup or backtracking. Supersession is by new dated artifact, never by editing the existing one.
 
 **Time:** 2-30 min active depending on calibrated depth.
 
@@ -176,9 +181,9 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 ### Step 9: Cleanup
 
-**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research archive entry's frontmatter still reflects the versions/decisions that landed (update `installed_versions_snapshot` if a version bumped during implementation). The archive entry itself persists outside the repo and is never deleted at this step — stale-trust protection lives in the frontmatter, not in deletion.
+**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research artifact's frontmatter still reflects the versions/decisions that landed. If a version bumped during implementation, supersede the existing artifact with a new dated one (new archive file, or new spike issue) rather than editing the existing one — snapshot semantics depend on each artifact being immutable. The original artifact persists (outside the repo for archive mode, in GitHub for spike-issue mode) and is never deleted at this step — stale-trust protection lives in the frontmatter and supersession discipline, not in deletion.
 
-**Output:** Closed issues. Archive entry retained as durable per-user context for future planning in the same area.
+**Output:** Closed issues. Research artifact retained as durable context for future planning in the same area.
 
 ### Pipeline Recovery
 
@@ -187,7 +192,7 @@ The pipeline described above is the forward path. This section covers what happe
 **When backtracking to an earlier skill:**
 
 - State which skill you are returning to and why.
-- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated archive entry — do not delete prior entries), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
+- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated artifact — new archive file or new spike issue depending on the project's `research.storage` mode; do not delete prior artifacts and do not edit them in place), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
 - Scope the re-run to what changed — do not restart the skill from scratch. Example: "We shaped X, but Y was wrong, so we are re-researching Z."
 - After the re-run, proceed forward through the pipeline again from that point.
 
@@ -229,7 +234,7 @@ A companion to Boundary Maps. The Boundary Map answers *what flows between slice
 | Work items (slices) | GitHub issues with blocking relationships | Native kanban, Ralph reads them |
 | QA bugs | GitHub issues | Created during manual QA, closed by Ralph |
 | Decisions register | Ubiquitous language doc (decisions section) | Co-located with terminology, single source of truth |
-| Technical research | Per-user archive at `~/.claude/research/<repo-slug>/<feature>-<date>.md` | Worktree- and branch-resilient; outside the repo; persists as durable planning context across features |
+| Technical research | Per-project, selected by `.claude/settings.json` `research.storage`. Default `archive` → per-user file at `~/.claude/research/<repo-slug>/<feature>-<date>.md`. Opt-in `spike-issue` → closed `research`-labeled GitHub issue in the same repo as the PRD | Storage location matches the project's audience flow without forcing a global rule. Archive is right for solo / single-machine / private work. Spike-issue is right for public, portfolio, OSS, multi-contributor, or multi-machine work where the PRD's audience reads via GitHub. Both carry the same frontmatter and equivalent authority |
 | Institutional knowledge | `docs/solutions/` in repo | Compounds over time, consulted during planning |
 | Workflow definitions | `.claude/skills/` in repo | Composable, load-on-demand, version-controlled |
 
@@ -264,7 +269,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 |---|---|---|---|
 | `/shape` | Fuzzy problem, unclear scope | Shared understanding — choices, assumptions, impositions, signals | `/research` (or `/create-milestone` for multi-PRD work) |
 | `/create-milestone` | `/shape` closing summary for a multi-PRD tranche | GitHub milestone plus sequenced feature issues | `/research` on a `research-ready` feature |
-| `/research` | Clarified problem from `/shape` | Archived research file at `~/.claude/research/<repo>/<feature>-<date>.md` with verified versions and doc links | `/write-a-prd` (may invoke `/api-design-review`) |
+| `/research` | Clarified problem from `/shape` | Research artifact with verified versions and doc links — per-user archive at `~/.claude/research/<repo>/<feature>-<date>.md` (default), or closed `research`-labeled GitHub spike issue when project opts in via `.claude/settings.json` `research.storage = spike-issue` | `/write-a-prd` (may invoke `/api-design-review`) |
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
@@ -419,7 +424,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Capture lessons learned | `/compound` after feature ships or after a high-value bug fix |
 | Define domain terms | `/ubiquitous-language` to build or update the glossary + decisions register, then reuse that language in shaping, QA, and issue writing |
 | Record a decision | Add a row to the decisions register in ubiquitous language doc |
-| Clean up after ship | Close the PRD issue and any remaining slice issues; the research archive entry persists outside the repo and is not deleted |
+| Clean up after ship | Close the PRD issue and any remaining slice issues; the research artifact persists (archive file outside the repo, or closed spike issue in GitHub) and is never deleted — supersede with a new dated artifact if research changes |
 | Audit TypeScript code quality | `/ts-audit` on a file, directory, or glob — produces a structured report of type-safety findings |
 | Figure out where I am in the pipeline | `/help` — reads repo state (branch, PRs, issues, research archive, milestones) and recommends the next skill with a one-line reason |
 | Audit knowledge base | Review `docs/solutions/` quarterly |

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -232,6 +232,7 @@ volatility: evergreen | stable | volatile
 
 - [Link to GitHub issue or PR if applicable]
 - [Link to related docs/solutions/ files if they exist]
+- [Link to the research spike issue when one exists for this feature — `Refs #<spike-issue-number>`. This preserves the causal chain from research → PRD → slices → PR → compound, citable from any machine. If the project uses archive-mode research instead, omit this link — archive paths are openable only by the originating user, so they add no value to a `docs/solutions/` entry that may be read by others.]
 
 ## Shelf Life
 

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -31,12 +31,12 @@ The pipeline order is the default path, not a prison. `Ralph` is the AFK executi
 **Artifact precedence.** When a skill consults multiple artifacts, resolve conflicts using this priority order:
 
 1. Working code in the repository (ground truth)
-2. The research archive entry for this feature (verified against installed versions at the `date` in its frontmatter)
+2. The research artifact for this feature — per-user archive entry or closed `research`-labeled spike issue, depending on the project's `research.storage` setting (verified against installed versions at the `date` in its frontmatter; storage location does not affect trust)
 3. `docs/solutions/` (compounded knowledge, possibly stale)
 4. Framework reference skills (general best practices)
 5. Model training data (least reliable for version-specific details)
 
-When the research archive entry and `docs/solutions/` disagree, the research entry wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
+When the research artifact and `docs/solutions/` disagree, the research artifact wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. The research artifact may live in either the per-user archive or as a closed `research`-labeled GitHub spike issue, depending on the project's `research.storage` setting; both carry equivalent authority because their bodies are produced by the same `/research` skill against the same Phase 0/1 verification. Storage location is a discoverability decision, not a trust decision. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
@@ -88,7 +88,12 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Staleness check:** When consulting `docs/solutions/`, `/research` checks the `volatility` field and date. Volatile solutions older than 90 days, or solutions whose Shelf Life condition appears met, are flagged as potentially stale before being incorporated.
 
-**Output:** One research file in the per-user archive at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness. Referenced in the PRD. Persists after ship — the archive is worktree- and branch-resilient and is not deleted during cleanup or backtracking.
+**Output:** One research artifact, location selected per project via `.claude/settings.json` `research.storage` (default `archive`):
+
+- **`archive`** — file at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Worktree- and branch-resilient. Right for solo / single-machine / private projects.
+- **`spike-issue`** — closed-on-creation GitHub issue in the same repo as the PRD, labeled `research`, with the same body and frontmatter the archive would carry. Reachable from any machine via `gh issue view`, citable from PRD/slice/PR/compound via `Refs #N`. Right for public, portfolio, OSS, transparency-themed, multi-contributor, or multi-machine projects.
+
+Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness regardless of storage location. Referenced in the PRD. Persists after ship — neither location is touched during cleanup or backtracking. Supersession is by new dated artifact, never by editing the existing one.
 
 **Time:** 2-30 min active depending on calibrated depth.
 
@@ -176,9 +181,9 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 ### Step 9: Cleanup
 
-**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research archive entry's frontmatter still reflects the versions/decisions that landed (update `installed_versions_snapshot` if a version bumped during implementation). The archive entry itself persists outside the repo and is never deleted at this step — stale-trust protection lives in the frontmatter, not in deletion.
+**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research artifact's frontmatter still reflects the versions/decisions that landed. If a version bumped during implementation, supersede the existing artifact with a new dated one (new archive file, or new spike issue) rather than editing the existing one — snapshot semantics depend on each artifact being immutable. The original artifact persists (outside the repo for archive mode, in GitHub for spike-issue mode) and is never deleted at this step — stale-trust protection lives in the frontmatter and supersession discipline, not in deletion.
 
-**Output:** Closed issues. Archive entry retained as durable per-user context for future planning in the same area.
+**Output:** Closed issues. Research artifact retained as durable context for future planning in the same area.
 
 ### Pipeline Recovery
 
@@ -187,7 +192,7 @@ The pipeline described above is the forward path. This section covers what happe
 **When backtracking to an earlier skill:**
 
 - State which skill you are returning to and why.
-- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated archive entry — do not delete prior entries), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
+- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated artifact — new archive file or new spike issue depending on the project's `research.storage` mode; do not delete prior artifacts and do not edit them in place), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
 - Scope the re-run to what changed — do not restart the skill from scratch. Example: "We shaped X, but Y was wrong, so we are re-researching Z."
 - After the re-run, proceed forward through the pipeline again from that point.
 
@@ -229,7 +234,7 @@ A companion to Boundary Maps. The Boundary Map answers *what flows between slice
 | Work items (slices) | GitHub issues with blocking relationships | Native kanban, Ralph reads them |
 | QA bugs | GitHub issues | Created during manual QA, closed by Ralph |
 | Decisions register | Ubiquitous language doc (decisions section) | Co-located with terminology, single source of truth |
-| Technical research | Per-user archive at `~/.claude/research/<repo-slug>/<feature>-<date>.md` | Worktree- and branch-resilient; outside the repo; persists as durable planning context across features |
+| Technical research | Per-project, selected by `.claude/settings.json` `research.storage`. Default `archive` → per-user file at `~/.claude/research/<repo-slug>/<feature>-<date>.md`. Opt-in `spike-issue` → closed `research`-labeled GitHub issue in the same repo as the PRD | Storage location matches the project's audience flow without forcing a global rule. Archive is right for solo / single-machine / private work. Spike-issue is right for public, portfolio, OSS, multi-contributor, or multi-machine work where the PRD's audience reads via GitHub. Both carry the same frontmatter and equivalent authority |
 | Institutional knowledge | `docs/solutions/` in repo | Compounds over time, consulted during planning |
 | Workflow definitions | `.claude/skills/` in repo | Composable, load-on-demand, version-controlled |
 
@@ -264,7 +269,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 |---|---|---|---|
 | `/shape` | Fuzzy problem, unclear scope | Shared understanding — choices, assumptions, impositions, signals | `/research` (or `/create-milestone` for multi-PRD work) |
 | `/create-milestone` | `/shape` closing summary for a multi-PRD tranche | GitHub milestone plus sequenced feature issues | `/research` on a `research-ready` feature |
-| `/research` | Clarified problem from `/shape` | Archived research file at `~/.claude/research/<repo>/<feature>-<date>.md` with verified versions and doc links | `/write-a-prd` (may invoke `/api-design-review`) |
+| `/research` | Clarified problem from `/shape` | Research artifact with verified versions and doc links — per-user archive at `~/.claude/research/<repo>/<feature>-<date>.md` (default), or closed `research`-labeled GitHub spike issue when project opts in via `.claude/settings.json` `research.storage = spike-issue` | `/write-a-prd` (may invoke `/api-design-review`) |
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
@@ -419,7 +424,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Capture lessons learned | `/compound` after feature ships or after a high-value bug fix |
 | Define domain terms | `/ubiquitous-language` to build or update the glossary + decisions register, then reuse that language in shaping, QA, and issue writing |
 | Record a decision | Add a row to the decisions register in ubiquitous language doc |
-| Clean up after ship | Close the PRD issue and any remaining slice issues; the research archive entry persists outside the repo and is not deleted |
+| Clean up after ship | Close the PRD issue and any remaining slice issues; the research artifact persists (archive file outside the repo, or closed spike issue in GitHub) and is never deleted — supersede with a new dated artifact if research changes |
 | Audit TypeScript code quality | `/ts-audit` on a file, directory, or glob — produces a structured report of type-safety findings |
 | Figure out where I am in the pipeline | `/help` — reads repo state (branch, PRs, issues, research archive, milestones) and recommends the next skill with a one-line reason |
 | Audit knowledge base | Review `docs/solutions/` quarterly |

--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -16,7 +16,7 @@ This is a primary pipeline skill used after `/prd-to-issues` has produced a conc
 
 Use `/execute` when the work is ready to build, verify, and commit.
 
-Use HITL `/execute` when the slice still needs active user judgment, supervision, or acceptance decisions during implementation. Use AFK `/execute` only when the next slice is already durable in GitHub, unblocked, and legible from its issue, boundary map, and any linked `research.md` or `docs/solutions/` context.
+Use HITL `/execute` when the slice still needs active user judgment, supervision, or acceptance decisions during implementation. Use AFK `/execute` only when the next slice is already durable in GitHub, unblocked, and legible from its issue, boundary map, and any linked research artifact (archive file or spike issue) or `docs/solutions/` context.
 
 See **Step 0: Prerequisites** below for the mandatory Ralph auto-detection and TDD marker gates.
 
@@ -129,7 +129,17 @@ This gate is scoped to intra-repo symbols (paths, exports, shapes). The mirror c
 
 Read any referenced plan, PRD, or GitHub issue. Explore the codebase to understand the relevant files, patterns, and conventions. If the task is ambiguous, ask the user to clarify scope before proceeding.
 
-If a `research.md` exists in the repo root or `plans/` directory, read it — it contains cached technical research that should inform your approach. Do not re-research what has already been decided.
+**Read the research artifact for this feature.** The PRD's "Research Reference" section names where it lives — one of two locations depending on the project's `research.storage` mode:
+
+1. **Spike-issue mode** — the PRD references a closed `research`-labeled GitHub issue (`Refs #<spike-issue-number>`). Read it with:
+   ```bash
+   gh issue view <spike-issue-number>
+   ```
+   This works on any machine — fresh clones, CI sandboxes, recovered laptops, or contributor environments.
+
+2. **Archive mode** (default) — the PRD references `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`. Read the file directly. If you are running on a machine other than the one that produced the research, the file will not exist; flag this to the user and either re-run `/research` or proceed with explicit acknowledgment of the missing context.
+
+Some legacy PRDs may still reference `research.md` in the repo root or `plans/` — read it if present. Whatever the location, the research artifact contains cached technical research that should inform your approach. Do not re-research what has already been decided.
 
 Consult `docs/solutions/` for relevant past solutions before starting implementation:
 
@@ -139,7 +149,7 @@ grep -rl "relevant-keyword" docs/solutions/ 2>/dev/null
 
 If past solutions exist for this problem domain, incorporate their lessons and avoid their documented pitfalls.
 
-**Artifact precedence:** When `research.md` and `docs/solutions/` give conflicting guidance, follow `research.md` — it was verified against the current installed versions. If the conflict is significant enough that you are uncertain, flag it to the user before proceeding. Load `docs/solutions/` selectively: grep for relevant keywords first, then read only matching files.
+**Artifact precedence:** When the research artifact and `docs/solutions/` give conflicting guidance, follow the research artifact — it was verified against the current installed versions. Storage location does not affect trust: a spike issue and an archive entry carry equivalent authority. If the conflict is significant enough that you are uncertain, flag it to the user before proceeding. Load `docs/solutions/` selectively: grep for relevant keywords first, then read only matching files.
 
 ### 2. Plan the Implementation (optional)
 
@@ -175,7 +185,7 @@ If `/tdd` is not available, follow this minimum discipline:
 
 Do not write all tests upfront — write one, make it pass, then move to the next.
 
-**[TypeScript projects] Library callback returns.** When a logical unit implements a callback the library asks the application to provide (agent hooks, middleware, proxy, tool handlers, render props, lifecycle methods), anchor the returned value to the library's declared return type with `satisfies LibraryReturnType`, a fresh object literal, or a derived type (`ReturnType<typeof …>`). Never return a typed local variable — TypeScript's excess-property check does not run on returns of typed values, so fields the library's signature does not declare are silently dropped at runtime. See `/tdd` Refactor step for the full rationale; if a `research.md` exists with a Library Callback Contracts snapshot (Phase 1.25), use its accepted-fields list as the pinned source.
+**[TypeScript projects] Library callback returns.** When a logical unit implements a callback the library asks the application to provide (agent hooks, middleware, proxy, tool handlers, render props, lifecycle methods), anchor the returned value to the library's declared return type with `satisfies LibraryReturnType`, a fresh object literal, or a derived type (`ReturnType<typeof …>`). Never return a typed local variable — TypeScript's excess-property check does not run on returns of typed values, so fields the library's signature does not declare are silently dropped at runtime. See `/tdd` Refactor step for the full rationale; if the research artifact (archive file or spike issue) carries a Library Callback Contracts snapshot (`/research` Phase 1.25), use its accepted-fields list as the pinned source.
 
 #### Commit after each logical unit
 
@@ -343,13 +353,13 @@ If you cannot complete the task in this context window, leave a comment on the G
 - Any gotchas or tricky parts for the next iteration
 - If the failure was caused by an error (build failure, test failure, unexpected API behavior), include the exact error output — the next iteration benefits from the real error, not a summary
 
-If the error suggests the approach from `research.md` or the PRD is wrong, say so in the comment — this is a signal to backtrack, not to keep retrying the same approach.
+If the error suggests the approach from the research artifact or the PRD is wrong, say so in the comment — this is a signal to backtrack, not to keep retrying the same approach.
 
 **AFK progress and plateau detection.** When running under Ralph, progress is *epistemic state advancement*, not activity. An iteration counts as progress only if at least one of these transitions from unresolved to resolved:
 
 - an unmet acceptance criterion on the active slice
 - a failing check (typecheck, test, or verification gate) becoming a passing check
-- a named unknown or rabbit hole from `research.md` or the PRD being closed
+- a named unknown or rabbit hole from the research artifact or the PRD being closed
 
 Code churn without such a transition is a stationary dot. Red flags: the same slice staying active across multiple iterations, tests still failing but "in different ways," recurring error classes with superficial code rewrites, no acceptance checkbox or gate advancing.
 

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -31,12 +31,12 @@ The pipeline order is the default path, not a prison. `Ralph` is the AFK executi
 **Artifact precedence.** When a skill consults multiple artifacts, resolve conflicts using this priority order:
 
 1. Working code in the repository (ground truth)
-2. The research archive entry for this feature (verified against installed versions at the `date` in its frontmatter)
+2. The research artifact for this feature — per-user archive entry or closed `research`-labeled spike issue, depending on the project's `research.storage` setting (verified against installed versions at the `date` in its frontmatter; storage location does not affect trust)
 3. `docs/solutions/` (compounded knowledge, possibly stale)
 4. Framework reference skills (general best practices)
 5. Model training data (least reliable for version-specific details)
 
-When the research archive entry and `docs/solutions/` disagree, the research entry wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
+When the research artifact and `docs/solutions/` disagree, the research artifact wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. The research artifact may live in either the per-user archive or as a closed `research`-labeled GitHub spike issue, depending on the project's `research.storage` setting; both carry equivalent authority because their bodies are produced by the same `/research` skill against the same Phase 0/1 verification. Storage location is a discoverability decision, not a trust decision. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
@@ -88,7 +88,12 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Staleness check:** When consulting `docs/solutions/`, `/research` checks the `volatility` field and date. Volatile solutions older than 90 days, or solutions whose Shelf Life condition appears met, are flagged as potentially stale before being incorporated.
 
-**Output:** One research file in the per-user archive at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness. Referenced in the PRD. Persists after ship — the archive is worktree- and branch-resilient and is not deleted during cleanup or backtracking.
+**Output:** One research artifact, location selected per project via `.claude/settings.json` `research.storage` (default `archive`):
+
+- **`archive`** — file at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Worktree- and branch-resilient. Right for solo / single-machine / private projects.
+- **`spike-issue`** — closed-on-creation GitHub issue in the same repo as the PRD, labeled `research`, with the same body and frontmatter the archive would carry. Reachable from any machine via `gh issue view`, citable from PRD/slice/PR/compound via `Refs #N`. Right for public, portfolio, OSS, transparency-themed, multi-contributor, or multi-machine projects.
+
+Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness regardless of storage location. Referenced in the PRD. Persists after ship — neither location is touched during cleanup or backtracking. Supersession is by new dated artifact, never by editing the existing one.
 
 **Time:** 2-30 min active depending on calibrated depth.
 
@@ -176,9 +181,9 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 ### Step 9: Cleanup
 
-**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research archive entry's frontmatter still reflects the versions/decisions that landed (update `installed_versions_snapshot` if a version bumped during implementation). The archive entry itself persists outside the repo and is never deleted at this step — stale-trust protection lives in the frontmatter, not in deletion.
+**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research artifact's frontmatter still reflects the versions/decisions that landed. If a version bumped during implementation, supersede the existing artifact with a new dated one (new archive file, or new spike issue) rather than editing the existing one — snapshot semantics depend on each artifact being immutable. The original artifact persists (outside the repo for archive mode, in GitHub for spike-issue mode) and is never deleted at this step — stale-trust protection lives in the frontmatter and supersession discipline, not in deletion.
 
-**Output:** Closed issues. Archive entry retained as durable per-user context for future planning in the same area.
+**Output:** Closed issues. Research artifact retained as durable context for future planning in the same area.
 
 ### Pipeline Recovery
 
@@ -187,7 +192,7 @@ The pipeline described above is the forward path. This section covers what happe
 **When backtracking to an earlier skill:**
 
 - State which skill you are returning to and why.
-- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated archive entry — do not delete prior entries), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
+- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated artifact — new archive file or new spike issue depending on the project's `research.storage` mode; do not delete prior artifacts and do not edit them in place), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
 - Scope the re-run to what changed — do not restart the skill from scratch. Example: "We shaped X, but Y was wrong, so we are re-researching Z."
 - After the re-run, proceed forward through the pipeline again from that point.
 
@@ -229,7 +234,7 @@ A companion to Boundary Maps. The Boundary Map answers *what flows between slice
 | Work items (slices) | GitHub issues with blocking relationships | Native kanban, Ralph reads them |
 | QA bugs | GitHub issues | Created during manual QA, closed by Ralph |
 | Decisions register | Ubiquitous language doc (decisions section) | Co-located with terminology, single source of truth |
-| Technical research | Per-user archive at `~/.claude/research/<repo-slug>/<feature>-<date>.md` | Worktree- and branch-resilient; outside the repo; persists as durable planning context across features |
+| Technical research | Per-project, selected by `.claude/settings.json` `research.storage`. Default `archive` → per-user file at `~/.claude/research/<repo-slug>/<feature>-<date>.md`. Opt-in `spike-issue` → closed `research`-labeled GitHub issue in the same repo as the PRD | Storage location matches the project's audience flow without forcing a global rule. Archive is right for solo / single-machine / private work. Spike-issue is right for public, portfolio, OSS, multi-contributor, or multi-machine work where the PRD's audience reads via GitHub. Both carry the same frontmatter and equivalent authority |
 | Institutional knowledge | `docs/solutions/` in repo | Compounds over time, consulted during planning |
 | Workflow definitions | `.claude/skills/` in repo | Composable, load-on-demand, version-controlled |
 
@@ -264,7 +269,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 |---|---|---|---|
 | `/shape` | Fuzzy problem, unclear scope | Shared understanding — choices, assumptions, impositions, signals | `/research` (or `/create-milestone` for multi-PRD work) |
 | `/create-milestone` | `/shape` closing summary for a multi-PRD tranche | GitHub milestone plus sequenced feature issues | `/research` on a `research-ready` feature |
-| `/research` | Clarified problem from `/shape` | Archived research file at `~/.claude/research/<repo>/<feature>-<date>.md` with verified versions and doc links | `/write-a-prd` (may invoke `/api-design-review`) |
+| `/research` | Clarified problem from `/shape` | Research artifact with verified versions and doc links — per-user archive at `~/.claude/research/<repo>/<feature>-<date>.md` (default), or closed `research`-labeled GitHub spike issue when project opts in via `.claude/settings.json` `research.storage = spike-issue` | `/write-a-prd` (may invoke `/api-design-review`) |
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
@@ -419,7 +424,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Capture lessons learned | `/compound` after feature ships or after a high-value bug fix |
 | Define domain terms | `/ubiquitous-language` to build or update the glossary + decisions register, then reuse that language in shaping, QA, and issue writing |
 | Record a decision | Add a row to the decisions register in ubiquitous language doc |
-| Clean up after ship | Close the PRD issue and any remaining slice issues; the research archive entry persists outside the repo and is not deleted |
+| Clean up after ship | Close the PRD issue and any remaining slice issues; the research artifact persists (archive file outside the repo, or closed spike issue in GitHub) and is never deleted — supersede with a new dated artifact if research changes |
 | Audit TypeScript code quality | `/ts-audit` on a file, directory, or glob — produces a structured report of type-safety findings |
 | Figure out where I am in the pipeline | `/help` — reads repo state (branch, PRs, issues, research archive, milestones) and recommends the next skill with a one-line reason |
 | Audit knowledge base | Review `docs/solutions/` quarterly |

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -31,12 +31,12 @@ The pipeline order is the default path, not a prison. `Ralph` is the AFK executi
 **Artifact precedence.** When a skill consults multiple artifacts, resolve conflicts using this priority order:
 
 1. Working code in the repository (ground truth)
-2. The research archive entry for this feature (verified against installed versions at the `date` in its frontmatter)
+2. The research artifact for this feature — per-user archive entry or closed `research`-labeled spike issue, depending on the project's `research.storage` setting (verified against installed versions at the `date` in its frontmatter; storage location does not affect trust)
 3. `docs/solutions/` (compounded knowledge, possibly stale)
 4. Framework reference skills (general best practices)
 5. Model training data (least reliable for version-specific details)
 
-When the research archive entry and `docs/solutions/` disagree, the research entry wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
+When the research artifact and `docs/solutions/` disagree, the research artifact wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. The research artifact may live in either the per-user archive or as a closed `research`-labeled GitHub spike issue, depending on the project's `research.storage` setting; both carry equivalent authority because their bodies are produced by the same `/research` skill against the same Phase 0/1 verification. Storage location is a discoverability decision, not a trust decision. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
@@ -88,7 +88,12 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Staleness check:** When consulting `docs/solutions/`, `/research` checks the `volatility` field and date. Volatile solutions older than 90 days, or solutions whose Shelf Life condition appears met, are flagged as potentially stale before being incorporated.
 
-**Output:** One research file in the per-user archive at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness. Referenced in the PRD. Persists after ship — the archive is worktree- and branch-resilient and is not deleted during cleanup or backtracking.
+**Output:** One research artifact, location selected per project via `.claude/settings.json` `research.storage` (default `archive`):
+
+- **`archive`** — file at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Worktree- and branch-resilient. Right for solo / single-machine / private projects.
+- **`spike-issue`** — closed-on-creation GitHub issue in the same repo as the PRD, labeled `research`, with the same body and frontmatter the archive would carry. Reachable from any machine via `gh issue view`, citable from PRD/slice/PR/compound via `Refs #N`. Right for public, portfolio, OSS, transparency-themed, multi-contributor, or multi-machine projects.
+
+Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness regardless of storage location. Referenced in the PRD. Persists after ship — neither location is touched during cleanup or backtracking. Supersession is by new dated artifact, never by editing the existing one.
 
 **Time:** 2-30 min active depending on calibrated depth.
 
@@ -176,9 +181,9 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 ### Step 9: Cleanup
 
-**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research archive entry's frontmatter still reflects the versions/decisions that landed (update `installed_versions_snapshot` if a version bumped during implementation). The archive entry itself persists outside the repo and is never deleted at this step — stale-trust protection lives in the frontmatter, not in deletion.
+**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research artifact's frontmatter still reflects the versions/decisions that landed. If a version bumped during implementation, supersede the existing artifact with a new dated one (new archive file, or new spike issue) rather than editing the existing one — snapshot semantics depend on each artifact being immutable. The original artifact persists (outside the repo for archive mode, in GitHub for spike-issue mode) and is never deleted at this step — stale-trust protection lives in the frontmatter and supersession discipline, not in deletion.
 
-**Output:** Closed issues. Archive entry retained as durable per-user context for future planning in the same area.
+**Output:** Closed issues. Research artifact retained as durable context for future planning in the same area.
 
 ### Pipeline Recovery
 
@@ -187,7 +192,7 @@ The pipeline described above is the forward path. This section covers what happe
 **When backtracking to an earlier skill:**
 
 - State which skill you are returning to and why.
-- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated archive entry — do not delete prior entries), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
+- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated artifact — new archive file or new spike issue depending on the project's `research.storage` mode; do not delete prior artifacts and do not edit them in place), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
 - Scope the re-run to what changed — do not restart the skill from scratch. Example: "We shaped X, but Y was wrong, so we are re-researching Z."
 - After the re-run, proceed forward through the pipeline again from that point.
 
@@ -229,7 +234,7 @@ A companion to Boundary Maps. The Boundary Map answers *what flows between slice
 | Work items (slices) | GitHub issues with blocking relationships | Native kanban, Ralph reads them |
 | QA bugs | GitHub issues | Created during manual QA, closed by Ralph |
 | Decisions register | Ubiquitous language doc (decisions section) | Co-located with terminology, single source of truth |
-| Technical research | Per-user archive at `~/.claude/research/<repo-slug>/<feature>-<date>.md` | Worktree- and branch-resilient; outside the repo; persists as durable planning context across features |
+| Technical research | Per-project, selected by `.claude/settings.json` `research.storage`. Default `archive` → per-user file at `~/.claude/research/<repo-slug>/<feature>-<date>.md`. Opt-in `spike-issue` → closed `research`-labeled GitHub issue in the same repo as the PRD | Storage location matches the project's audience flow without forcing a global rule. Archive is right for solo / single-machine / private work. Spike-issue is right for public, portfolio, OSS, multi-contributor, or multi-machine work where the PRD's audience reads via GitHub. Both carry the same frontmatter and equivalent authority |
 | Institutional knowledge | `docs/solutions/` in repo | Compounds over time, consulted during planning |
 | Workflow definitions | `.claude/skills/` in repo | Composable, load-on-demand, version-controlled |
 
@@ -264,7 +269,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 |---|---|---|---|
 | `/shape` | Fuzzy problem, unclear scope | Shared understanding — choices, assumptions, impositions, signals | `/research` (or `/create-milestone` for multi-PRD work) |
 | `/create-milestone` | `/shape` closing summary for a multi-PRD tranche | GitHub milestone plus sequenced feature issues | `/research` on a `research-ready` feature |
-| `/research` | Clarified problem from `/shape` | Archived research file at `~/.claude/research/<repo>/<feature>-<date>.md` with verified versions and doc links | `/write-a-prd` (may invoke `/api-design-review`) |
+| `/research` | Clarified problem from `/shape` | Research artifact with verified versions and doc links — per-user archive at `~/.claude/research/<repo>/<feature>-<date>.md` (default), or closed `research`-labeled GitHub spike issue when project opts in via `.claude/settings.json` `research.storage = spike-issue` | `/write-a-prd` (may invoke `/api-design-review`) |
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
@@ -419,7 +424,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Capture lessons learned | `/compound` after feature ships or after a high-value bug fix |
 | Define domain terms | `/ubiquitous-language` to build or update the glossary + decisions register, then reuse that language in shaping, QA, and issue writing |
 | Record a decision | Add a row to the decisions register in ubiquitous language doc |
-| Clean up after ship | Close the PRD issue and any remaining slice issues; the research archive entry persists outside the repo and is not deleted |
+| Clean up after ship | Close the PRD issue and any remaining slice issues; the research artifact persists (archive file outside the repo, or closed spike issue in GitHub) and is never deleted — supersede with a new dated artifact if research changes |
 | Audit TypeScript code quality | `/ts-audit` on a file, directory, or glob — produces a structured report of type-safety findings |
 | Figure out where I am in the pipeline | `/help` — reads repo state (branch, PRs, issues, research archive, milestones) and recommends the next skill with a one-line reason |
 | Audit knowledge base | Review `docs/solutions/` quarterly |

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -60,7 +60,7 @@ Boundary maps are API contracts, not just dependency inventories — if a slice 
 For each slice, specify:
 
 - **Produces:** The concrete outputs — exported functions, types/interfaces, API endpoints, database tables, UI components. Include file paths and function signatures where possible.
-- **Consumes from #N:** What this slice needs from upstream slices — specific imports, API endpoints it calls, types it uses. Reference the producing slice by number.
+- **Consumes from #N:** What this slice needs from upstream slices — specific imports, API endpoints it calls, types it uses. Reference the producing slice by number. If the parent PRD's research lives in a `research`-labeled spike issue (see `/research` Phase 5d), you may also cite `Refs #<spike-issue-number>` here when the slice's interface decisions are bounded by a specific recommendation, callback contract, or version snapshot recorded in that spike. The `Refs #N` lineage syntax is the same one used elsewhere in the pipeline.
 - **Contract notes:** The success shape, error shape, compatibility posture, and any versioning readiness concerns that matter to downstream consumers.
 
 The boundary map prevents the most common multi-slice failure: slices that are each internally correct but don't actually wire together because they made incompatible assumptions about interfaces.
@@ -174,6 +174,7 @@ What this slice creates that downstream slices depend on:
 What this slice needs from upstream slices:
 
 - From #<issue-number>: `path/to/file.ts` → `importedFunction()`, `ImportedType`
+- Refs #<spike-issue-number>: research spike pinning the recommended approach or library callback contract this slice's interface depends on (cite only when a spike issue exists for this PRD's research and the slice is bounded by a specific recommendation in it)
 
 Or "Nothing — this is a leaf node (no upstream dependencies)." if no dependencies.
 

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -228,15 +228,36 @@ For API-shaped work, explicitly document:
 
 ### Phase 5: Write the Research Document
 
-Write the research document to a durable, per-user archive outside the repo working tree:
+The research document has two possible storage locations, selected per project. Both carry the same body and the same frontmatter — the difference is **where the file lives**, not what it contains. Pick the storage mode first, then write.
 
+#### Phase 5a: Select the Storage Mode
+
+Read the project-level config to determine where this research goes:
+
+```bash
+# Read the research.storage field from the project-local settings file.
+# Default to "archive" if the file or field is missing.
+jq -r '.research.storage // "archive"' .claude/settings.json 2>/dev/null || echo archive
 ```
-~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md
+
+The two modes:
+
+- **`archive`** (default) — write to a per-user filesystem path outside the repo working tree (`~/.claude/research/...`). Worktree- and branch-resilient, never committed, never visible to collaborators. Right for solo / single-machine / private projects.
+- **`spike-issue`** — file the research as a closed-on-creation GitHub issue in the same repo as the PRD, labeled `research`. Right for public, portfolio, OSS, transparency-themed, multi-contributor, or multi-machine projects where the PRD's audience is GitHub and the research must be openable by that audience without per-user setup. Spike issue visibility follows the repo's visibility — private repos produce private spikes.
+
+Tell the user which mode was selected and why (e.g., `"spike-issue mode: .claude/settings.json declares research.storage = spike-issue"`). If neither mode is configured, default to `archive` and proceed.
+
+To opt a project into spike-issue mode, add this to `.claude/settings.json` (Claude Code ignores fields outside its schema, so this is additive — Skill Kit owns the `research` namespace):
+
+```json
+{
+  "research": { "storage": "spike-issue" }
+}
 ```
 
-Where `<repo-slug>` is `owner-name` derived from the git remote (e.g. `chrislacey89-skills`), `<feature-slug>` is a short kebab-case phrase naming the feature, and `<YYYY-MM-DD>` is today's date. Create intermediate directories if they do not exist.
+#### Phase 5b: Compose the Frontmatter
 
-Start the file with YAML frontmatter so future consumers can judge freshness:
+Both modes carry identical frontmatter so future readers can judge freshness regardless of where the file lives:
 
 ```yaml
 ---
@@ -255,7 +276,56 @@ callback_contracts_snapshot:
 ---
 ```
 
+#### Phase 5c — Archive mode (default): Write to the Per-User Archive
+
+When the storage mode is `archive`, write the research document to the per-user archive outside the repo working tree:
+
+```
+~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md
+```
+
+Where `<repo-slug>` is `owner-name` derived from the git remote (e.g. `chrislacey89-skills`), `<feature-slug>` is a short kebab-case phrase naming the feature, and `<YYYY-MM-DD>` is today's date. Create intermediate directories if they do not exist.
+
 **Why outside the repo:** the archive is per-user working memory, not team-shared artifact. Branch switches, worktree cleanup, and `.gitignore` hygiene cannot accidentally destroy it. It is not committed to the project and is never visible to collaborators.
+
+When this mode is selected, skip Phase 5d. The PRD's Research Reference section will emit the archive path.
+
+#### Phase 5d — Spike-issue mode: File as a Closed GitHub Issue
+
+When the storage mode is `spike-issue`, file the research as a labeled, closed-on-creation GitHub issue in the same repo as the PRD will live. The PRD's Research Reference section will emit the issue URL (`Refs #N`) instead of an archive path.
+
+1. **Ensure the `research` label exists** (idempotent — first run creates it, subsequent runs are no-ops):
+
+   ```bash
+   gh label create research --color BFD4F2 --description "Research spike — closed-on-creation, frontmatter-pinned" 2>/dev/null || true
+   ```
+
+2. **Compose the issue body.** Take the entire research document (including the YAML frontmatter from Phase 5b) and use it as the issue body verbatim. Frontmatter inside the issue body is rendered as a code block by GitHub but remains machine-readable to downstream skills.
+
+3. **Create the issue and capture the URL:**
+
+   ```bash
+   SPIKE_URL=$(gh issue create \
+     --title "Research: <Feature Name> (<YYYY-MM-DD>)" \
+     --label research \
+     --body-file <path-to-temp-file-with-research-body>)
+   ```
+
+   Use a title format that makes the issue scannable in default issue lists: `Research: <feature> (<date>)`.
+
+4. **Close the issue immediately.** Closed-on-creation signals "research complete, point-in-time snapshot" — not "archive purged":
+
+   ```bash
+   gh issue close "$SPIKE_URL" --comment "Closed on creation — see body for the point-in-time research snapshot. Do not edit; supersede with a new dated spike issue if research changes."
+   ```
+
+5. **Cache locally for this session.** Also write the same body to the archive path (`~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`) so the rest of this session and any sibling tools that read the archive can find it. The spike issue is the canonical durable copy; the cache is a session convenience and may be safely overwritten on re-runs.
+
+6. **Emit both the spike URL and the cache path** when reporting the completed research, and note that the canonical home is the spike issue.
+
+**Why a spike issue:** lives outside the working tree (no destructive-git risk between write and push), reachable by the PRD's audience (`Refs #N` syntax), durable across machines (`gh issue view N` works anywhere), and labeled-and-closed so it stays out of `is:open` work-to-do views.
+
+**Mutability discipline:** the issue body is a point-in-time snapshot, not a living document. Do not edit it after creation. If research changes, file a new dated spike issue and update the PRD's Research Reference to point at the new one — the same superseded-by-new-dated-file rule the archive follows.
 
 **Include only sections that have real content.** A TARGETED research doc might be 20 lines. A DEEP one might be 300. This document is the compressed handoff to `/write-a-prd` — once written, the downstream skill works from this file, not from the raw research exploration. If this session is running long, suggest starting `/write-a-prd` in a fresh session using the archive path as input.
 
@@ -437,20 +507,25 @@ Present the research document to the user. Then walk through these review questi
 3. Any version surprises that change your thinking?
 4. Are you comfortable proceeding to PRD with this recommendation?
 
-Do not present all four questions at once. Iterate on each answer until the user is satisfied. The research file is saved to the archive path outside the repo — do not commit it to git.
+Do not present all four questions at once. Iterate on each answer until the user is satisfied.
+
+In archive mode, the research file is saved outside the repo — do not commit it to git. In spike-issue mode, the research lives as a closed GitHub issue and a session-local cache copy at the archive path; do not commit the cache copy either.
 
 ## Handoff
 
 - **Expected input:** clarified problem framing from `/shape`, including choices, assumptions, impositions, and structural signals
-- **Produces:** an archived research file at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, verified version and documentation guidance, and a clearer estimate-readiness posture
+- **Produces:** a research artifact carrying verified version and documentation guidance plus an estimate-readiness posture. Storage location depends on the project's `research.storage` setting:
+  - **`archive`** (default): file at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`
+  - **`spike-issue`**: closed GitHub issue labeled `research` in the same repo as the PRD, plus a session-local cache copy at the archive path
 - **May invoke:** `/api-design-review` when contract risk is high enough that the API shape needs focused scrutiny before shaping continues
 - **Comes next by default:** `/write-a-prd`
 
 ## Lifecycle
 
-**The research file is a point-in-time snapshot.** It exists to serve the PRD and Ralph loop during active work, and then persists as durable per-user context for future planning in the same area.
+**The research artifact is a point-in-time snapshot.** It exists to serve the PRD and Ralph loop during active work, and then persists as durable context for future planning in the same area.
 
-- Reference the archive path in your PRD so Ralph reads it during implementation.
-- After the feature ships, the archive entry persists automatically — do not delete it. Branch switches, worktree cleanup, and `/compound`'s closeout step cannot touch it because it lives outside the repo.
-- Stale research actively harms agent performance — a research file that recommends Ably v1.2 when v2.0 has breaking changes will steer Ralph in the wrong direction. The frontmatter `date` and `installed_versions_snapshot` let future readers judge whether the snapshot is still trustworthy before they rely on it.
-- This skill does not yet auto-consult prior archive entries during Phase 0 — that capability is a separate follow-on. For now, the archive is simply durable storage that won't be lost to ordinary git workflow.
+- Reference the canonical location in your PRD (archive path or spike issue URL) so `/execute` and Ralph can read it during implementation.
+- After the feature ships, the artifact persists automatically — do not delete it. Branch switches, worktree cleanup, and `/compound`'s closeout step cannot touch the archive entry (it lives outside the repo) or the spike issue (it lives in GitHub).
+- Stale research actively harms agent performance — a research artifact that recommends Ably v1.2 when v2.0 has breaking changes will steer Ralph in the wrong direction. The frontmatter `date` and `installed_versions_snapshot` let future readers judge whether the snapshot is still trustworthy before they rely on it.
+- **Supersession, not editing.** If research changes, write a new dated artifact (new archive file, or new spike issue) and point the PRD at the new one. Do not edit the old artifact in place — the snapshot semantics depend on each artifact being immutable. Spike issues should not gain comments or body edits over time; the closed-on-creation state and the convention against edits are the substitute for the archive's filesystem-imposed immutability.
+- This skill does not yet auto-consult prior archive entries or prior spike issues during Phase 0 — that capability is a separate follow-on.

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -31,12 +31,12 @@ The pipeline order is the default path, not a prison. `Ralph` is the AFK executi
 **Artifact precedence.** When a skill consults multiple artifacts, resolve conflicts using this priority order:
 
 1. Working code in the repository (ground truth)
-2. The research archive entry for this feature (verified against installed versions at the `date` in its frontmatter)
+2. The research artifact for this feature — per-user archive entry or closed `research`-labeled spike issue, depending on the project's `research.storage` setting (verified against installed versions at the `date` in its frontmatter; storage location does not affect trust)
 3. `docs/solutions/` (compounded knowledge, possibly stale)
 4. Framework reference skills (general best practices)
 5. Model training data (least reliable for version-specific details)
 
-When the research archive entry and `docs/solutions/` disagree, the research entry wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
+When the research artifact and `docs/solutions/` disagree, the research artifact wins because it was produced more recently and verified against installed versions — subject to the `date` and `installed_versions_snapshot` in its frontmatter still being plausibly current. The research artifact may live in either the per-user archive or as a closed `research`-labeled GitHub spike issue, depending on the project's `research.storage` setting; both carry equivalent authority because their bodies are produced by the same `/research` skill against the same Phase 0/1 verification. Storage location is a discoverability decision, not a trust decision. Flag the conflict to the user rather than silently choosing. Load `docs/solutions/` on demand — grep for relevant keywords first, read only matching files — rather than loading everything upfront.
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
@@ -88,7 +88,12 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 **Staleness check:** When consulting `docs/solutions/`, `/research` checks the `volatility` field and date. Volatile solutions older than 90 days, or solutions whose Shelf Life condition appears met, are flagged as potentially stale before being incorporated.
 
-**Output:** One research file in the per-user archive at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness. Referenced in the PRD. Persists after ship — the archive is worktree- and branch-resilient and is not deleted during cleanup or backtracking.
+**Output:** One research artifact, location selected per project via `.claude/settings.json` `research.storage` (default `archive`):
+
+- **`archive`** — file at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md`, outside the repo. Worktree- and branch-resilient. Right for solo / single-machine / private projects.
+- **`spike-issue`** — closed-on-creation GitHub issue in the same repo as the PRD, labeled `research`, with the same body and frontmatter the archive would carry. Reachable from any machine via `gh issue view`, citable from PRD/slice/PR/compound via `Refs #N`. Right for public, portfolio, OSS, transparency-themed, multi-contributor, or multi-machine projects.
+
+Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot` so future readers can judge freshness regardless of storage location. Referenced in the PRD. Persists after ship — neither location is touched during cleanup or backtracking. Supersession is by new dated artifact, never by editing the existing one.
 
 **Time:** 2-30 min active depending on calibrated depth.
 
@@ -176,9 +181,9 @@ For milestone-planned work, `/research` does not consume a raw `roadmap bet`. It
 
 ### Step 9: Cleanup
 
-**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research archive entry's frontmatter still reflects the versions/decisions that landed (update `installed_versions_snapshot` if a version bumped during implementation). The archive entry itself persists outside the repo and is never deleted at this step — stale-trust protection lives in the frontmatter, not in deletion.
+**What it does:** Close the PRD issue and any remaining slice issues as shipped, and confirm the research artifact's frontmatter still reflects the versions/decisions that landed. If a version bumped during implementation, supersede the existing artifact with a new dated one (new archive file, or new spike issue) rather than editing the existing one — snapshot semantics depend on each artifact being immutable. The original artifact persists (outside the repo for archive mode, in GitHub for spike-issue mode) and is never deleted at this step — stale-trust protection lives in the frontmatter and supersession discipline, not in deletion.
 
-**Output:** Closed issues. Archive entry retained as durable per-user context for future planning in the same area.
+**Output:** Closed issues. Research artifact retained as durable context for future planning in the same area.
 
 ### Pipeline Recovery
 
@@ -187,7 +192,7 @@ The pipeline described above is the forward path. This section covers what happe
 **When backtracking to an earlier skill:**
 
 - State which skill you are returning to and why.
-- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated archive entry — do not delete prior entries), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
+- If the backtrack invalidates a written artifact: supersede it (re-run `/research` to produce a new dated artifact — new archive file or new spike issue depending on the project's `research.storage` mode; do not delete prior artifacts and do not edit them in place), update in place (PRD issue body), or close with a comment explaining the backtrack (slice issues). Do not leave stale artifacts for downstream skills to consume.
 - Scope the re-run to what changed — do not restart the skill from scratch. Example: "We shaped X, but Y was wrong, so we are re-researching Z."
 - After the re-run, proceed forward through the pipeline again from that point.
 
@@ -229,7 +234,7 @@ A companion to Boundary Maps. The Boundary Map answers *what flows between slice
 | Work items (slices) | GitHub issues with blocking relationships | Native kanban, Ralph reads them |
 | QA bugs | GitHub issues | Created during manual QA, closed by Ralph |
 | Decisions register | Ubiquitous language doc (decisions section) | Co-located with terminology, single source of truth |
-| Technical research | Per-user archive at `~/.claude/research/<repo-slug>/<feature>-<date>.md` | Worktree- and branch-resilient; outside the repo; persists as durable planning context across features |
+| Technical research | Per-project, selected by `.claude/settings.json` `research.storage`. Default `archive` → per-user file at `~/.claude/research/<repo-slug>/<feature>-<date>.md`. Opt-in `spike-issue` → closed `research`-labeled GitHub issue in the same repo as the PRD | Storage location matches the project's audience flow without forcing a global rule. Archive is right for solo / single-machine / private work. Spike-issue is right for public, portfolio, OSS, multi-contributor, or multi-machine work where the PRD's audience reads via GitHub. Both carry the same frontmatter and equivalent authority |
 | Institutional knowledge | `docs/solutions/` in repo | Compounds over time, consulted during planning |
 | Workflow definitions | `.claude/skills/` in repo | Composable, load-on-demand, version-controlled |
 
@@ -264,7 +269,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 |---|---|---|---|
 | `/shape` | Fuzzy problem, unclear scope | Shared understanding — choices, assumptions, impositions, signals | `/research` (or `/create-milestone` for multi-PRD work) |
 | `/create-milestone` | `/shape` closing summary for a multi-PRD tranche | GitHub milestone plus sequenced feature issues | `/research` on a `research-ready` feature |
-| `/research` | Clarified problem from `/shape` | Archived research file at `~/.claude/research/<repo>/<feature>-<date>.md` with verified versions and doc links | `/write-a-prd` (may invoke `/api-design-review`) |
+| `/research` | Clarified problem from `/shape` | Research artifact with verified versions and doc links — per-user archive at `~/.claude/research/<repo>/<feature>-<date>.md` (default), or closed `research`-labeled GitHub spike issue when project opts in via `.claude/settings.json` `research.storage = spike-issue` | `/write-a-prd` (may invoke `/api-design-review`) |
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
@@ -419,7 +424,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Capture lessons learned | `/compound` after feature ships or after a high-value bug fix |
 | Define domain terms | `/ubiquitous-language` to build or update the glossary + decisions register, then reuse that language in shaping, QA, and issue writing |
 | Record a decision | Add a row to the decisions register in ubiquitous language doc |
-| Clean up after ship | Close the PRD issue and any remaining slice issues; the research archive entry persists outside the repo and is not deleted |
+| Clean up after ship | Close the PRD issue and any remaining slice issues; the research artifact persists (archive file outside the repo, or closed spike issue in GitHub) and is never deleted — supersede with a new dated artifact if research changes |
 | Audit TypeScript code quality | `/ts-audit` on a file, directory, or glob — produces a structured report of type-safety findings |
 | Figure out where I am in the pipeline | `/help` — reads repo state (branch, PRs, issues, research archive, milestones) and recommends the next skill with a one-line reason |
 | Audit knowledge base | Review `docs/solutions/` quarterly |

--- a/write-a-prd/SKILL.md
+++ b/write-a-prd/SKILL.md
@@ -73,13 +73,23 @@ grep -rl "relevant-keyword" docs/solutions/ 2>/dev/null
 ```
 If relevant solutions exist, read them. Incorporate their lessons into your understanding of the problem space. Surface relevant pitfalls, patterns, or decisions to the user during the interview — "We've hit X before in a similar feature, and the solution was Y. Should we apply the same pattern here?"
 
-**Research document** — Check the durable per-user archive for a research file matching this feature. Derive `<repo-slug>` from the current git remote (e.g. `chrislacey89-skills`) and list the archive directory for this repo:
-```bash
-ls ~/.claude/research/<repo-slug>/ 2>/dev/null
-```
-Pick the entry whose `feature` frontmatter field (or filename slug) matches this feature. Before trusting it, check the frontmatter `date` and `installed_versions_snapshot` — if either looks stale against current reality, flag it to the user. If a research document exists and is fresh, read it thoroughly. It contains the technical approach already researched and recommended during the `/research` phase. The pitch should build on these recommendations rather than re-debating them. Reference the archive path in the pitch so Ralph reads it during implementation.
+**Research document** — Find the most recent research artifact for this feature. The artifact may live in either of two places depending on the project's `research.storage` setting:
 
-**Artifact precedence:** When the research file and `docs/solutions/` disagree, the research file takes precedence — it was verified against installed versions. Surface the conflict to the user during the interview rather than silently choosing one.
+1. **Spike-issue mode** — search GitHub for closed `research`-labeled issues matching the feature:
+   ```bash
+   gh issue list --label research --state closed --search "<feature keywords>" --limit 5
+   ```
+   If a matching spike issue exists, read its body — the YAML frontmatter at the top carries the same `date` and `installed_versions_snapshot` fields the archive uses.
+
+2. **Archive mode** (default) — list the per-user archive for this repo. Derive `<repo-slug>` from the current git remote (e.g. `chrislacey89-skills`):
+   ```bash
+   ls ~/.claude/research/<repo-slug>/ 2>/dev/null
+   ```
+   Pick the entry whose `feature` frontmatter field (or filename slug) matches this feature.
+
+Check both locations — a project that recently switched modes may still have artifacts in the old location. If both exist for the same feature, prefer the more recent `date` in frontmatter and surface the duplicate to the user. Before trusting any research artifact, check the frontmatter `date` and `installed_versions_snapshot` — if either looks stale against current reality, flag it to the user. If a research artifact exists and is fresh, read it thoroughly. It contains the technical approach already researched and recommended during the `/research` phase. The pitch should build on these recommendations rather than re-debating them. Reference the canonical location (spike issue URL or archive path) in the pitch so `/execute` and Ralph can read it during implementation.
+
+**Artifact precedence:** When the research artifact and `docs/solutions/` disagree, the research artifact takes precedence — it was verified against installed versions. Storage location does not affect trust: a spike issue and an archive entry carry equivalent authority because their bodies are produced by the same `/research` skill against the same Phase 0/1 verification. Surface the conflict to the user during the interview rather than silently choosing one.
 
 ### 5. Interview with shaping discipline
 
@@ -279,14 +289,25 @@ Do NOT include specific file paths or code snippets. They may end up being outda
 
 ## Research Reference
 
-[Include only if a matching research archive entry exists]
+[Include only if a matching research artifact exists. Use the form that matches the project's `research.storage` mode.]
+
+**Spike-issue mode (preferred when present):**
+
+Technical research for this feature is documented in spike issue Refs #<spike-issue-number> (closed-on-creation snapshot, labeled `research`). Key recommendations:
+
+- [Recommended approach from research]
+- [Key constraint or tradeoff from research]
+
+Implementors should read the spike issue before starting work (`gh issue view <spike-issue-number>` works on any machine).
+
+**Archive mode (fallback when no spike issue exists):**
 
 Technical research for this feature is documented at `~/.claude/research/<repo-slug>/<feature-slug>-<YYYY-MM-DD>.md` (per-user archive, outside the repo). Key recommendations:
 
 - [Recommended approach from research]
 - [Key constraint or tradeoff from research]
 
-Implementors should read the research document before starting work.
+Implementors should read the research document before starting work. Archive paths are not openable by readers other than the originating user — for cross-machine, multi-contributor, or public-audience PRDs, opt the project into spike-issue mode (see `/research` Phase 5a).
 
 ## Lessons from Past Solutions
 


### PR DESCRIPTION
## Summary

`/research` now supports an opt-in storage mode that files research as a closed, `research`-labeled GitHub issue in the same repo as the PRD, instead of (or in addition to) the per-user filesystem archive. The default stays `archive` — issue #2's analysis is unchanged for solo / single-machine / private projects. Projects whose PRDs are read by an audience that lives on GitHub — public, portfolio, OSS, transparency-themed, multi-contributor, or multi-machine — can now opt in via `.claude/settings.json` `{"research": {"storage": "spike-issue"}}` and get research that is openable by the same audience that opens the PRD.

The change is per-project (one config flag), not per-invocation, to keep optionality at the lowest cognitive cost. Spike issues are closed on creation (so they stay out of `is:open` work-to-do views), labeled `research` (so they stay scoped on lookup), and carry the same YAML frontmatter the archive does (`date`, `installed_versions_snapshot`, optional `callback_contracts_snapshot`) so freshness checks port unchanged. They also write a session-local cache copy at the archive path so anything else in the same session can find the body without a second `gh` round-trip. Storage location is treated as a *discoverability* decision throughout the pipeline, not a *trust* decision: spike issues and archive entries carry equivalent authority because both are produced by the same `/research` skill against the same Phase 0/1 verification.

Downstream skills update to consume both modes. `/write-a-prd` Step 4 checks both spike-issue search (`gh issue list --label research --state closed`) and the archive listing, prefers the more recent `date`, and emits the appropriate Research Reference variant in the pitch template. `/prd-to-issues` lets a slice's Boundary Map Consumes section cite `Refs #<spike>` when the slice's interface is bounded by a recommendation pinned in the spike. `/execute` Step 1 reads research from `gh issue view N` (works on any machine — fresh clones, CI sandboxes, contributor environments) or the archive path, and the AFK Ralph plateau-detection language now refers to "the research artifact" instead of "research.md". `/compound`'s Related section conditionally cross-links the spike issue, preserving the causal chain research → PRD → slices → PR → compound in a form readers other than the originating user can actually open. `SYSTEM-OVERVIEW.md`'s Where State Lives table, Step 2 description, artifact-precedence rule, Pipeline Recovery, Handoff Table, and Quick Reference all update to reflect the per-project choice.

## PRD

Closes #34

## Key Decisions

- **Configuration location:** `.claude/settings.json` `research.storage` field, per the proposal in #34. Claude Code ignores fields outside its harness schema, so this is additive — Skill Kit owns the `research` namespace. If we later want stricter separation, moving to a dedicated file (`.claude/skill-kit.json`) is a one-line change in `/research` Phase 5a.
- **Snapshot semantics by convention, not by lock:** spike issues are closed-on-creation and the docs explicitly say "do not edit; supersede with a new dated spike issue if research changes." GitHub's lock-issue feature is a follow-up if mutability drift becomes observable — kept out of v1 per #34's non-goals.
- **Spike-issue mode also writes the archive cache:** redundant by design. The spike issue is canonical, but a session-local archive copy lets sibling skills that look at the archive path find the body without a `gh` round-trip and gives a fast offline read during the same session.
- **Single commit, not per-file:** the change is one coherent mechanism whose intermediate states (e.g., `/write-a-prd` referencing spike-issue mode before `/research` defines it) wouldn't make sense as standalone commits. Bundled `references/SYSTEM-OVERVIEW.md` syncs ride along.
- **Full proposal scope, not just `/research` Phase 1:** chose the broader path over the author's recommended atomic-first scope so there's no intermediate state where a spike URL is created but not consumed downstream. Trade-off is larger blast radius; mitigation is that all behavior is opt-in and the default path is unchanged.