### PR TITLE
improve-pipeline: pin architecture vocabulary, add Deletion + two-adapters checks, add qa wontfix lookback

### DIFF
--- a/improve-codebase-architecture/REFERENCE.md
+++ b/improve-codebase-architecture/REFERENCE.md
@@ -16,7 +16,7 @@ Dependencies that have local test stand-ins (e.g., PGLite for Postgres, in-memor
 
 ### 3. Remote but owned (Ports & Adapters)
 
-Your own modules across a network seam (microservices, internal services). Define an interface at the seam — "port" in ports-and-adapters terminology, but `Interface` in the pinned vocabulary. The deep module owns the logic; the transport is injected. Tests use an in-memory adapter. Production uses the real HTTP/gRPC/queue adapter.
+Your own modules deployed across a network seam (microservices, internal modules behind a transport). Define an interface at the seam — "port" in ports-and-adapters terminology, but Interface in the pinned vocabulary. The deep module owns the logic; the transport is injected. Tests use an in-memory adapter. Production uses the real HTTP/gRPC/queue adapter.
 
 Recommendation shape: "Define a shared interface, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic can be tested as one deep module even though it's deployed across a network seam."
 

--- a/improve-codebase-architecture/REFERENCE.md
+++ b/improve-codebase-architecture/REFERENCE.md
@@ -64,7 +64,7 @@ Which category applies and how dependencies are handled:
 
 ## Testing Strategy
 
-- **New boundary tests to write**: describe the behaviors to verify at the interface
+- **New seam tests to write**: describe the behaviors to verify at the interface
 - **Old tests to delete**: list the shallow module tests that become redundant
 - **Test environment needs**: any local stand-ins or adapters required
 

--- a/improve-codebase-architecture/REFERENCE.md
+++ b/improve-codebase-architecture/REFERENCE.md
@@ -1,5 +1,7 @@
 # Reference
 
+This file goes deeper on dependency strategy, testing strategy, and the RFC issue template. The pinned working vocabulary lives in [SKILL.md](SKILL.md) — use those terms (Module, Interface, Implementation, Depth, Seam, Adapter, Leverage, Locality) here too.
+
 ## Dependency Categories
 
 When assessing a candidate for deepening, classify its dependencies:
@@ -14,20 +16,20 @@ Dependencies that have local test stand-ins (e.g., PGLite for Postgres, in-memor
 
 ### 3. Remote but owned (Ports & Adapters)
 
-Your own services across a network boundary (microservices, internal APIs). Define a port (interface) at the module boundary. The deep module owns the logic; the transport is injected. Tests use an in-memory adapter. Production uses the real HTTP/gRPC/queue adapter.
+Your own modules across a network seam (microservices, internal services). Define an interface at the seam — "port" in ports-and-adapters terminology, but `Interface` in the pinned vocabulary. The deep module owns the logic; the transport is injected. Tests use an in-memory adapter. Production uses the real HTTP/gRPC/queue adapter.
 
-Recommendation shape: "Define a shared interface (port), implement an HTTP adapter for production and an in-memory adapter for testing, so the logic can be tested as one deep module even though it's deployed across a network boundary."
+Recommendation shape: "Define a shared interface, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic can be tested as one deep module even though it's deployed across a network seam."
 
 ### 4. True external (Mock)
 
-Third-party services (Stripe, Twilio, etc.) you don't control. Mock at the boundary. The deepened module takes the external dependency as an injected port, and tests provide a mock implementation.
+Third-party services (Stripe, Twilio, etc.) you don't control. Mock at the seam. The deepened module takes the external dependency as an injected interface, and tests provide a mock adapter.
 
 ## Testing Strategy
 
 The core principle: **replace, don't layer.**
 
-- Old unit tests on shallow modules are waste once boundary tests exist — delete them
-- Write new tests at the deepened module's interface boundary
+- Old unit tests on shallow modules are waste once seam tests exist — delete them
+- Write new tests at the deepened module's interface
 - Tests assert on observable outcomes through the public interface, not internal state
 - Tests should survive internal refactors — they describe behavior, not implementation
 
@@ -58,7 +60,7 @@ Which category applies and how dependencies are handled:
 - **In-process**: merged directly
 - **Local-substitutable**: tested with [specific stand-in]
 - **Ports & adapters**: port definition, production adapter, test adapter
-- **Mock**: mock boundary for external services
+- **Mock**: mock adapter at the interface for external services
 
 ## Testing Strategy
 

--- a/improve-codebase-architecture/SKILL.md
+++ b/improve-codebase-architecture/SKILL.md
@@ -12,7 +12,20 @@ sources:
 
 Explore a codebase like an AI would, surface architectural friction, discover opportunities for improving testability, and propose module-deepening refactors as GitHub issue RFCs.
 
-A **deep module** (John Ousterhout, "A Philosophy of Software Design") has a small interface hiding a large implementation. Deep modules are more testable, more AI-navigable, and let you test at the boundary instead of inside.
+A **deep module** (John Ousterhout, "A Philosophy of Software Design") has a small interface hiding a large implementation. Deep modules are more testable, more AI-navigable, and let you test at the seam instead of inside.
+
+## Working vocabulary
+
+Use these terms exactly when describing architectural opportunities, in conversation with the user, in candidate write-ups, and in the resulting RFC issue. Do not drift into "component," "service," "API," or "boundary" — they read as synonyms but each one hides a different design decision and the slippage compounds across recommendations.
+
+- **Module** — a unit of code that callers interact with through a stable interface. Files, classes, packages, or directories can all be modules; the test is whether something on the outside depends on something on the inside.
+- **Interface** — the surface a module presents to callers: types, methods, parameters, return shapes, errors. Not the implementation.
+- **Implementation** — the code behind the interface that callers do not see and should not depend on.
+- **Depth** — the ratio of implementation hidden to interface exposed. Deep = a lot hidden behind a narrow surface; shallow = the interface is nearly as complex as the body.
+- **Seam** — a place in the codebase where one module ends and another begins. Tests are written *at* seams; refactors *move* them.
+- **Adapter** — a concrete implementation of an interface that bridges to a specific technology, transport, or external service. In-memory adapters serve tests; HTTP/SDK/queue adapters serve production.
+- **Leverage** — how much downstream work a single change at this seam buys. Deepening a high-leverage module simplifies many callers; deepening a low-leverage one moves complexity around without saving anyone work.
+- **Locality** — how much a reader must hold in working memory to understand a module. High locality = fewer files and fewer hops to grasp the behavior.
 
 ## Invocation Position
 
@@ -40,12 +53,20 @@ The friction you encounter IS the signal.
 
 ### 2. Present candidates
 
-Present a numbered list of deepening opportunities. For each candidate, show:
+Before adding a candidate to the list, run two filters. Both compress otherwise-judgmental architecture decisions into checks that anyone reading the recommendation can re-run.
 
-- **Cluster**: Which modules/concepts are involved
+- **Deletion test.** Imagine the candidate module deleted in place. Where does its complexity go? If the complexity vanishes — callers were doing the real work and the module was a pass-through that just renamed things — the candidate is a real deepening target. If the complexity concentrates across N callers — they would each need to re-derive what the module was doing — the module is already carrying real abstraction; leave it alone. A pass-through whose deletion makes callers simpler is a shallow module hiding behind a thin name.
+- **Two-adapters rule** (only when the candidate's design would introduce a new seam — i.e., add an interface that did not exist before). Confirm there are at least two real adapters: production *and* test, or two production transports. One adapter is a hypothetical seam — speculative generality with no second user — and should be deferred until a second consumer exists. Two adapters is a real seam worth defining.
+
+Candidates that fail either filter are noted as "considered and rejected" with the reason, not silently dropped — the rejection is part of the recommendation.
+
+Present a numbered list of the candidates that pass. For each, show:
+
+- **Cluster**: Which modules are involved
 - **Why they're coupled**: Shared types, call patterns, co-ownership of a concept
+- **Depth signal**: One sentence summarizing what the Deletion test surfaced (what hides behind the current interface, or what the pass-through shows)
 - **Dependency category**: See [REFERENCE.md](REFERENCE.md) for the four categories
-- **Test impact**: What existing tests would be replaced by boundary tests
+- **Test impact**: What existing tests would be replaced by seam tests at the deepened module's interface
 
 Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
 
@@ -70,7 +91,7 @@ Prompt each sub-agent with a separate technical brief (file paths, coupling deta
 - Agent 1: "Minimize the interface — aim for 1-3 entry points max"
 - Agent 2: "Maximize flexibility — support many use cases and extension"
 - Agent 3: "Optimize for the most common caller — make the default case trivial"
-- Agent 4 (if applicable): "Design around the ports & adapters pattern for cross-boundary dependencies"
+- Agent 4 (if applicable): "Design around the ports & adapters pattern for dependencies that cross a process or network seam"
 
 Each sub-agent outputs:
 

--- a/improve-codebase-architecture/SKILL.md
+++ b/improve-codebase-architecture/SKILL.md
@@ -63,8 +63,7 @@ Candidates that fail either filter are noted as "considered and rejected" with t
 Present a numbered list of the candidates that pass. For each, show:
 
 - **Cluster**: Which modules are involved
-- **Why they're coupled**: Shared types, call patterns, co-ownership of a concept
-- **Depth signal**: One sentence summarizing what the Deletion test surfaced (what hides behind the current interface, or what the pass-through shows)
+- **Why they're coupled**: Shared types, call patterns, co-ownership of a concept — fold in a one-sentence summary of what the Deletion test surfaced (what hides behind the current interface, or what the pass-through shows)
 - **Dependency category**: See [REFERENCE.md](REFERENCE.md) for the four categories
 - **Test impact**: What existing tests would be replaced by seam tests at the deepened module's interface
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -94,6 +94,26 @@ If Step 3 produced a breakdown, apply this depth decision to each sub-issue inde
 
 This step runs only for issues that stayed lightweight in Step 3.5. Issues that delegated to `/triage-issue` are already filed by that skill and skip this step.
 
+#### 4a. Closed-wontfix lookback (before filing)
+
+Before creating each issue, search closed `wontfix` issues for the same idea. Already-rejected enhancements resurfacing as fresh issues consume triage cycles every time:
+
+```bash
+gh issue list --state closed --label wontfix --search "<keywords from this report>"
+```
+
+Pick keywords from the user's own description and the domain language you learned in Step 2 — not internal module names. Run the search before each issue, not once per session.
+
+If a prior rejection surfaces:
+
+- If the new report adds genuinely new evidence (a stronger user case, a regression that wasn't there at rejection time, a constraint that has changed), reopen the prior issue and add the new evidence as a comment — do not file a duplicate.
+- If the new report is the same idea with no new evidence, link the prior closed issue back to the user with a one-sentence summary of why it was rejected, and ask whether they want to reopen with new evidence or accept the prior decision. Do not silently file a duplicate.
+- If unsure, link the prior issue in the new issue's body so the rejection rationale is one click away for the next reviewer.
+
+This is a process check, not an enforcement gate — closed-wontfix history is treated as durable state that lives in GitHub. Skill Kit deliberately does not maintain a parallel filesystem archive of rejected enhancements (per `SYSTEM-OVERVIEW.md` "State lives in GitHub, not the filesystem").
+
+#### 4b. Create the issue
+
 Create issues with `gh issue create`. Do NOT ask the user to review first — just file and share URLs.
 
 Issues must be **durable** — they should still make sense after major refactors. Write from the user's perspective.


### PR DESCRIPTION
## Summary

Two pipeline-level improvements surfaced by a comparative review of mattpocock/skills against the current pipeline (issue #39). Both stay inside Skill Kit's existing principles — no new artifacts, no parallel filesystem state — and target the two skills where the gaps concentrated.

**`/improve-codebase-architecture` — vocabulary discipline and two compact heuristics.** The skill previously used "module," "interface," "boundary," "component," and "service" interchangeably, leaving readers to reconstruct the working vocabulary from context. This PR pins eight terms at the top — `Module, Interface, Implementation, Depth, Seam, Adapter, Leverage, Locality` — and forbids drift into the looser synonyms. It adds two filters at Step 2 (Present candidates) that compress otherwise-judgmental architecture decisions into checks anyone can re-run: the **Deletion test** (imagine the module deleted; does complexity vanish or concentrate?) and the **two-adapters rule** (one adapter is a hypothetical seam, two is a real seam). Both map to Ousterhout's red-flag posture and turn shallow-module detection into a checklist item rather than gut-feel.

**`/qa` — closed-wontfix lookback before filing.** Already-rejected enhancements were resurfacing as fresh issues every triage cycle. Step 4a now runs ` + '`gh issue list --state closed --label wontfix --search "<keywords>"`' + ` before each new lightweight issue and resolves to one of three actions: reopen with new evidence, link the rejection back to the user, or link the prior issue in the new one. The check stays inside the GitHub-as-state principle — a parallel filesystem archive (mattpocock's `.out-of-scope/`) was deliberately rejected because closed wontfix issues already carry the same information without duplicating state.

**Adjacent edits.** `improve-codebase-architecture/REFERENCE.md` was swept to align with the pinned vocabulary — "boundary tests" → "seam tests," "module boundary" → "interface" or "seam" — and now cross-references the SKILL glossary so the two files don't drift. "Port" stays only as a parenthetical aside because the canonical term in this skill is Interface.

Closes #39.

## Key Decisions

- **Reject `.out-of-scope/`.** Closed wontfix issues are the archive. A filesystem mirror duplicates state and complicates the discoverability story (where do I look first?). Cited inline in `qa/SKILL.md` Step 4a so the rejection rationale is durable.
- **Two filters at Step 2, not Step 5.** The Deletion test and two-adapters rule act as candidate filters, not design checks. Failing candidates are noted as "considered and rejected" with the reason — not silently dropped — so the rejection is part of the recommendation.
- **Eight terms, not five.** The original proposal listed five (Depth, Seam, Adapter, Leverage, Locality); the implementation pinned eight by adding `Module, Interface, Implementation` to anchor the foundational nouns the other terms reference.