### PR TITLE
Runtime handoff line at end of every primary pipeline skill

### DIFF
--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -47,7 +47,7 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 **Input:** <artifact path, issue or PR number, or "use the closing summary above">
 ```
 
-The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
 
 ### Step 1: /shape (Matt's, enhanced)
 

--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -40,6 +40,15 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
+**Runtime handoff line.** Every primary pipeline skill prints a `**Next session:**` block at the end of its closing output, in this exact shape:
+
+```
+**Next session:** /<next-skill> [arg]
+**Input:** <artifact path, issue or PR number, or "use the closing summary above">
+```
+
+The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+
 ### Step 1: /shape (Matt's, enhanced)
 
 **What it does:** Interviews you relentlessly about the feature or tranche until every branch of the decision tree is resolved.

--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` |
+| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -42,6 +42,8 @@ Without this step, you've done traditional engineering with AI assistance. The f
 - For trivial fixes (typo corrections, simple config changes)
 - When the solution is already well-documented in official library docs
 - When the lesson is project-specific but you're about to deprecate that code
+- When the work was a clean execution of a pre-shaped plan — no surprises, no rework, no non-obvious decisions. The issue body and PR description already carry that record; a `docs/solutions/` entry with no reusable lesson trains future readers to skim
+- When in doubt — skipping costs nothing because the issue and PR persist in GitHub. Capturing a low-value lesson costs future planners' attention every time they consult `docs/solutions/`
 
 ## Execution Flow
 

--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -267,7 +267,7 @@ git commit -m "docs: compound — <brief description of what was learned>"
 
 ### Phase 6: Report
 
-Tell the user what was captured:
+Tell the user what was captured, then print the loop-closed line:
 
 ```
 Compounded: docs/solutions/<category>/<filename>.md
@@ -275,7 +275,11 @@ Compounded: docs/solutions/<category>/<filename>.md
 Key lesson: [One sentence summary of the most important takeaway]
 
 This will be consulted automatically during future /research and /write-a-prd sessions.
+
+**Loop closed.** Next: /help when you return to this repo.
 ```
+
+`/compound` is the end of the loop, so it does not print a `**Next session:**` line — the loop-closed line is the runtime-handoff equivalent. `/help` is only a suggested re-entry point; the user may also re-enter via `/shape`, `/qa`, or any other appropriate skill.
 
 ## Maintenance
 

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -47,7 +47,7 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 **Input:** <artifact path, issue or PR number, or "use the closing summary above">
 ```
 
-The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
 
 ### Step 1: /shape (Matt's, enhanced)
 

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -40,6 +40,15 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
+**Runtime handoff line.** Every primary pipeline skill prints a `**Next session:**` block at the end of its closing output, in this exact shape:
+
+```
+**Next session:** /<next-skill> [arg]
+**Input:** <artifact path, issue or PR number, or "use the closing summary above">
+```
+
+The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+
 ### Step 1: /shape (Matt's, enhanced)
 
 **What it does:** Interviews you relentlessly about the feature or tranche until every branch of the decision tree is resolved.

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` |
+| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -346,6 +346,15 @@ rm -f "$CLAUDE_PROJECT_DIR/.claude/.tdd-active" "$CLAUDE_PROJECT_DIR/.claude/.td
 
 **Auto-invoke `/pre-merge`.** If Step 5 ran and the user confirmed the "Ready for PR Review" item, invoke `/pre-merge` now. If the task originated from a PRD issue, pass the issue number so `/pre-merge` can gather slice lineage and verify boundary map contracts without asking the user for it again. If the user answered "no" to the PR review item, or Step 5 was skipped entirely (AFK Ralph iterations, trivial-task flows that never reached a user checklist), `/execute` exits here and the user invokes `/pre-merge` manually when ready.
 
+**Print the runtime handoff line.** Whether `/pre-merge` is auto-invoked or the user is exiting to invoke it manually later, print the line so a fresh session can open by copy-paste:
+
+```
+**Next session:** /pre-merge
+**Input:** the verified commits on branch <branch-name>
+```
+
+Substitute `<branch-name>` with the actual branch the commits live on (`git branch --show-current`).
+
 If you cannot complete the task in this context window, leave a comment on the GitHub issue with:
 
 - What was done

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -47,7 +47,7 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 **Input:** <artifact path, issue or PR number, or "use the closing summary above">
 ```
 
-The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
 
 ### Step 1: /shape (Matt's, enhanced)
 

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -40,6 +40,15 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
+**Runtime handoff line.** Every primary pipeline skill prints a `**Next session:**` block at the end of its closing output, in this exact shape:
+
+```
+**Next session:** /<next-skill> [arg]
+**Input:** <artifact path, issue or PR number, or "use the closing summary above">
+```
+
+The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+
 ### Step 1: /shape (Matt's, enhanced)
 
 **What it does:** Interviews you relentlessly about the feature or tranche until every branch of the decision tree is resolved.

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` |
+| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -47,7 +47,7 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 **Input:** <artifact path, issue or PR number, or "use the closing summary above">
 ```
 
-The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
 
 ### Step 1: /shape (Matt's, enhanced)
 

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -40,6 +40,15 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
+**Runtime handoff line.** Every primary pipeline skill prints a `**Next session:**` block at the end of its closing output, in this exact shape:
+
+```
+**Next session:** /<next-skill> [arg]
+**Input:** <artifact path, issue or PR number, or "use the closing summary above">
+```
+
+The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+
 ### Step 1: /shape (Matt's, enhanced)
 
 **What it does:** Interviews you relentlessly about the feature or tranche until every branch of the decision tree is resolved.

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` |
+| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -236,6 +236,15 @@ After all issues are created, present a summary showing:
 
 This summary helps the user (and Ralph) understand the full picture before execution begins. The Coverage Matrix remains a derived view — future readers regenerate it from the PRD issue body and the slice issues' `User Stories Addressed` sections rather than reading a stored matrix file.
 
+**At the end of the summary, print the runtime handoff line** naming the first unblocked slice (the slice with no `Blocked by` entry, or the lowest-numbered such slice when several qualify):
+
+```
+**Next session:** /execute #<first-unblocked-slice-number>
+**Input:** the slice issue body
+```
+
+If every slice declares `Blocked by`, surface the dependency cycle to the user before printing — do not pick arbitrarily.
+
 ## Handoff
 
 - **Expected input:** a shaped PRD issue with clear user stories, rabbit holes, and no-gos

--- a/pre-merge/SKILL.md
+++ b/pre-merge/SKILL.md
@@ -167,6 +167,15 @@ If a finding looks like a behavioral bug, note: "Consider running `/qa` to verif
 
 Omit any tier that has zero findings.
 
+**At the very end of Phase 4 output, print the runtime handoff line:**
+
+```
+**Next session:** /compound
+**Input:** PR #<pr-number>
+```
+
+Substitute `<pr-number>` with the PR created in Phase 2. Print this line whether or not the review surfaced concerns — `/compound` runs after merge regardless, and the line is the durable handoff for the post-ship session.
+
 ## What This Skill is NOT
 
 - **Not a test runner.** Pre-commit hooks run tests, typecheck, and lint on every commit.

--- a/pre-merge/SKILL.md
+++ b/pre-merge/SKILL.md
@@ -167,14 +167,14 @@ If a finding looks like a behavioral bug, note: "Consider running `/qa` to verif
 
 Omit any tier that has zero findings.
 
-**At the very end of Phase 4 output, print the runtime handoff line:**
+**At the very end of Phase 4 output, print the runtime handoff line if — and only if — a durable lesson emerged from this work that future `/research` or `/write-a-prd` would benefit from:**
 
 ```
 **Next session:** /compound
 **Input:** PR #<pr-number>
 ```
 
-Substitute `<pr-number>` with the PR created in Phase 2. Print this line whether or not the review surfaced concerns — `/compound` runs after merge regardless, and the line is the durable handoff for the post-ship session.
+Substitute `<pr-number>` with the PR created in Phase 2. Skip the line when the work was a clean execution of a pre-shaped plan with no surprises, rework, or non-obvious decisions — the issue body and PR description already carry that record, and a `docs/solutions/` entry with no reusable lesson trains future readers to skim. When in doubt, skip. Signals that a lesson is worth capturing: a tricky bug whose root cause was non-obvious, a Rabbit Hole from the PRD that actually bit, an architectural decision with significant tradeoffs, or a pattern that should be reused. See `/compound`'s "When NOT to Use" for the full skip list.
 
 ## What This Skill is NOT
 
@@ -188,4 +188,4 @@ Substitute `<pr-number>` with the PR created in Phase 2. Print this line whether
 - **Expected input:** verified implementation work that is ready for review and PR creation
 - **Produces:** a PR with lineage plus an architectural review readout
 - **May redirect:** to `/qa` when a finding looks behavioral, or to `/request-refactor-plan` when deeper structural cleanup is warranted
-- **Comes next by default:** merge, then `/compound`
+- **Comes next by default:** merge. Then `/compound` only when a durable lesson emerged worth capturing in `docs/solutions/` — skip it when the work was a clean execution of a pre-shaped plan

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -505,11 +505,20 @@ Present the research document to the user. Then walk through these review questi
 1. Does the recommended approach match your instinct?
 2. Are there options I missed that you'd like investigated?
 3. Any version surprises that change your thinking?
-4. Are you comfortable proceeding to PRD with this recommendation?
+4. Where do you want to run `/write-a-prd` — **here** (continue in this session) or in a **fresh session** using the printed handoff line below?
 
-Do not present all four questions at once. Iterate on each answer until the user is satisfied.
+Do not present all four questions at once. Iterate on each answer until the user is satisfied. Question 4 has exactly two answers — do not improvise a third option ("not yet", "later"). If the user is not ready to proceed, return to questions 1–3 to surface what is missing.
 
 In archive mode, the research file is saved outside the repo — do not commit it to git. In spike-issue mode, the research lives as a closed GitHub issue and a session-local cache copy at the archive path; do not commit the cache copy either.
+
+**At the end of Phase 6, print the runtime handoff line:**
+
+```
+**Next session:** /write-a-prd <feature-name>
+**Input:** <archive-path-or-spike-issue-url>
+```
+
+For archive mode, the input is the absolute path under `~/.claude/research/<repo-slug>/`. For spike-issue mode, the input is the closed GitHub issue URL. Print this line whether the user chose to continue here or in a fresh session — the line is the durable handoff either way.
 
 ## Handoff
 

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -47,7 +47,7 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 **Input:** <artifact path, issue or PR number, or "use the closing summary above">
 ```
 
-The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
 
 ### Step 1: /shape (Matt's, enhanced)
 

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -40,6 +40,15 @@ When the research artifact and `docs/solutions/` disagree, the research artifact
 
 **Planning-chain compression.** Each pipeline handoff has a compression artifact: the closing summary (`/shape`), the archived research file (`/research`), the PRD issue (`/write-a-prd`). The downstream skill should work from the written artifact, not from the full prior conversation. If a session is running long after multiple planning skills, start the next pipeline step in a fresh session using the written artifact as its entry point.
 
+**Runtime handoff line.** Every primary pipeline skill prints a `**Next session:**` block at the end of its closing output, in this exact shape:
+
+```
+**Next session:** /<next-skill> [arg]
+**Input:** <artifact path, issue or PR number, or "use the closing summary above">
+```
+
+The block surfaces existing handoff data (skill identity, compression artifact) at the decision point so a developer running a long session can move to a fresh session by copy-paste rather than by remembering. It is one short block — not a new section, not a paragraph, not a copy-paste cheat sheet — and it draws its data from the skill's existing `## Handoff` section. The skill at the end of the loop (`/compound`) prints `**Loop closed.** Next: /help when you return to this repo` instead.
+
 ### Step 1: /shape (Matt's, enhanced)
 
 **What it does:** Interviews you relentlessly about the feature or tranche until every branch of the decision tree is resolved.

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` |
+| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/shape/SKILL.md
+++ b/shape/SKILL.md
@@ -119,6 +119,15 @@ If any item is unchecked, ask one targeted question to fill the gap before prese
 
 For work that requires multiple independent PRDs — where the shaped outcome decomposes into several features that each need their own research-PRD cycle — use this same closing summary as the compressed handoff to `/create-milestone` instead. `/create-milestone` should use it to define a GitHub milestone, feature sequencing, and the first feature to promote from `roadmap bet` to `research-ready`. Note: a blank project or large-scope effort that is still one cohesive product stays on the default path; `/write-a-prd` will create a container milestone for big-batch work.
 
+**At the end of the closing summary, print the runtime handoff line** (default path):
+
+```
+**Next session:** /research <feature-slug>
+**Input:** paste the closing summary above
+```
+
+For the milestone branch, print `/create-milestone <feature-slug>` instead of `/research <feature-slug>` on the first line; the input remains the closing summary.
+
 ## Handoff
 
 Hand off to `/research` by default. For work that requires multiple independent PRDs — where the shaped outcome decomposes into several features that each need their own research-PRD cycle — branch to `/create-milestone` instead. Big-batch work (6 weeks) that fits a single PRD stays on the default path and gets a container milestone from `/write-a-prd`. Treat assumptions by confidence tag: `Uncertain` and `Speculative` assumptions are first-priority research targets because they carry the most downstream risk. `Likely` assumptions can usually be confirmed during PRD writing. `Established` assumptions need only targeted verification.

--- a/write-a-prd/SKILL.md
+++ b/write-a-prd/SKILL.md
@@ -319,7 +319,10 @@ The following documented solutions informed this pitch:
 
 ---
 
-**Next step:** run `/prd-to-issues <this-issue-number>` to decompose this PRD into implementation-ready slices with boundary maps. Do not invoke `/execute` directly on this issue — it is a shaped pitch, not a slice.
+**Next session:** /prd-to-issues #<this-issue-number>
+**Input:** the PRD issue body
+
+Do not invoke `/execute` directly on this issue — it is a shaped pitch, not a slice. Print the issue number explicitly so the next session can be opened by copy-paste rather than by fishing for it.
 
 </pitch-template>
 


### PR DESCRIPTION
## Summary

Closes #35. The pipeline already documents what each skill produces and which skill comes next (`SYSTEM-OVERVIEW.md` "Planning-chain compression" plus per-skill `## Handoff` sections), but none of that data showed up at runtime in the agent's closing output. So a developer running a long planning chain — `/shape` → `/research` → `/write-a-prd` in one session — had to *remember* to start the next step in a fresh session. The signifier existed; the affordance didn't.

This change makes the existing data surface at the decision point. Every primary pipeline skill (`/shape`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`) now prints a one-block runtime handoff at the very end of its closing output:

```
**Next session:** /<next-skill> [arg]
**Input:** <artifact path or "use the closing summary above">
```

`/compound` ends the loop, so it prints `**Loop closed.** Next: /help when you return to this repo.` instead. The format is formalized in a new "Runtime handoff line" subsection under SYSTEM-OVERVIEW.md "Planning-chain compression" (per-skill prints draw their data from there, and from each skill's existing `## Handoff` section — no new state, no new artifacts).

`/research` Phase 6 question 4 was tightened to two options ("here" vs. "fresh session via printed line below") so the runtime line becomes the load-bearing artifact at the highest-leverage transition — which was the original incident in #35.

This follows the issue's Mediator Verdict narrowly: one short block per skill, no new sections in skill bodies, no copy-paste cheat sheets. The existing prose handoff guidance stays as orientation; the runtime print is purely additive.

## PRD

Closes #35

## Slices

This PRD ships in one slice (per its Follow-On Options: "Should fit in one /execute slice"), so there are no separate slice issues to enumerate.

## Key Decisions

- **Format chosen for `/compound`:** The issue's Mediator Verdict said `/compound` should print `**Loop closed.** Next: /help when you return to this repo`. I baked this into the existing Phase 6 report block rather than as a separate post-block line, and added a one-sentence note that `/help` is only a *suggested* re-entry point (a user might re-enter via `/shape`, `/qa`, or anything else). Avoids implying the user must always run `/help` next.
- **`/shape` milestone branch:** The issue table only specified the default `/research` handoff. I added a one-line variant so the milestone branch (`/create-milestone`) gets the same runtime print — otherwise the milestone path silently regresses to the pre-change state.
- **`/research` Phase 6 Q4:** Changed to two named options ("here" vs. "fresh session"). I added a guard sentence forbidding a third option ("not yet", "later") and routing those answers back to questions 1–3, since the runtime line is meant to be the durable artifact regardless of which option is chosen.
- **`/execute` Step 6 placement:** Inserted the print between the auto-invoke paragraph and the "If you cannot complete the task" fallback, so the line is printed in both the auto-invoke and exit-cleanly paths.
- **`/pre-merge` Phase 4 placement:** Print at the very end of Phase 4 output (after the advisory tail) rather than embedded in the architectural review template, so it shows up regardless of whether the diff produced findings.