### PR TITLE
Add reviewer-mode + comment-craft to /pre-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The pipeline is the default path, not a prison. Skills can backtrack when assump
 | Skill | Description |
 |-------|-------------|
 | [qa](qa/) | Single entry point for bug conversations; files lightweight issues and delegates per-issue to `/triage-issue` for deep diagnosis |
-| [pre-merge](pre-merge/) | Create the PR and run an architectural review before merge |
+| [pre-merge](pre-merge/) | Author-mode: create the PR and run an architectural review before merge. Reviewer-mode (`--pr <n>`): review someone else's PR and draft comment text |
 | [compound](compound/) | Capture lessons learned into docs/solutions/ |
 | [ubiquitous-language](ubiquitous-language/) | DDD glossary with decisions register |
 

--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
+| `/pre-merge` | Verified implementation ready to review (author-mode), or an existing PR number to review (reviewer-mode via `--pr <n>`) | PR with lineage plus architectural review readout (author-mode), or draft PR comment text shaped by `references/comment-craft.md` (reviewer-mode) | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
+| `/pre-merge` | Verified implementation ready to review (author-mode), or an existing PR number to review (reviewer-mode via `--pr <n>`) | PR with lineage plus architectural review readout (author-mode), or draft PR comment text shaped by `references/comment-craft.md` (reviewer-mode) | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
+| `/pre-merge` | Verified implementation ready to review (author-mode), or an existing PR number to review (reviewer-mode via `--pr <n>`) | PR with lineage plus architectural review readout (author-mode), or draft PR comment text shaped by `references/comment-craft.md` (reviewer-mode) | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
+| `/pre-merge` | Verified implementation ready to review (author-mode), or an existing PR number to review (reviewer-mode via `--pr <n>`) | PR with lineage plus architectural review readout (author-mode), or draft PR comment text shaped by `references/comment-craft.md` (reviewer-mode) | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |

--- a/pre-merge/SKILL.md
+++ b/pre-merge/SKILL.md
@@ -12,21 +12,31 @@ Create a GitHub PR linking back to the PRD and slice issues, then review the ful
 
 ## Invocation Position
 
-This is a primary pipeline skill used after implementation has been verified and before merging to main.
+This is a primary pipeline skill used after implementation has been verified and before merging to main, *or* when picking up someone else's PR for review.
 
-Use `/pre-merge` when the branch is ready for PR creation, architectural review, and final plan-to-code reconciliation.
+Use `/pre-merge` when the branch is ready for PR creation, architectural review, and final plan-to-code reconciliation. Use `/pre-merge --pr <number>` when you are reviewing a PR you did not author.
 
 Do not use it as a substitute for implementation verification, QA intake, or refactor planning. It assumes the work is already built and ready to review.
 
+## Modes
+
+`/pre-merge` runs in one of two modes. Both reuse Phase 3's 10 architectural review dimensions (`review-checklist.md`); they differ in what they consume and what they produce.
+
+- **Author-mode (default)** — invoked on your own branch with no `--pr` argument. The skill creates the PR (Phase 2) and prints findings to the terminal as advisories (Phase 4). This is the mode auto-invoked by `/execute` Step 6.
+- **Reviewer-mode** — invoked as `/pre-merge --pr <number>` against a PR you did not author. The skill skips PR creation (the PR already exists) and produces *draft comment text* (Phase 4) for you to review and post, structured per `references/comment-craft.md` (5P gate, Triple-R, Comment Signals, MMG Exchange).
+
+If you are running on a branch other than the user's working branch and `--pr` was not provided, ask once whether the user means reviewer-mode against a specific PR number rather than guessing — auto-detection saves a keystroke but misclassifying mode produces draft comments that would have been local advisories or vice versa.
+
 ## When to Use
 
-- After QA passes and before merging a feature branch to main
-- After Ralph finishes AFK execution and you've verified behavior
-- For any branch you want reviewed before merge, even without a full pipeline run
+- **Author-mode:** after QA passes and before merging a feature branch to main; after Ralph finishes AFK execution and you've verified behavior; or for any branch you want reviewed before merge, even without a full pipeline run.
+- **Reviewer-mode:** when a teammate or external contributor opens a PR and you want to apply the 10-dimension architectural review to their diff and produce constructive comment text.
 
 ## Execution Flow
 
 ### Phase 1: Gather Context
+
+**Author-mode:**
 
 1. **Ask for the PRD issue number.** Accept "none" if this change didn't go through the full pipeline.
 
@@ -50,7 +60,22 @@ Do not use it as a substitute for implementation verification, QA intake, or ref
    ```
    For a stacked-PR slice, override `$BASE_BRANCH` with the sibling slice's branch name (the upstream the PR will target). If no diff from the base, tell the user there's nothing to review and stop. Do not hardcode `main` — Skill Kit's own repo uses `prod`, and many others use `develop`, `trunk`, or a team-specific name.
 
+**Reviewer-mode (`--pr <number>`):**
+
+1. **Fetch the PR and its diff:**
+   ```bash
+   gh pr view <pr-number> --json number,title,headRefName,baseRefName,body,author,url,state
+   gh pr diff <pr-number>
+   ```
+   If the PR is already merged or closed, tell the user and stop — review comments on a closed PR are surfaced separately and rarely useful.
+
+2. **Identify the PRD issue from the PR body.** Look for `Closes #<n>`, `Refs #<n>`, or a `## PRD` section pointing at an issue. If found, run the same `gh issue view` + slice-issue search as author-mode step 2 to load PRD context and boundary maps. If the PR has no PRD lineage, treat it as the "no PRD" branch — Phase 3's PRD-gated dimensions (Boundary Map Contracts, Coverage Matrix Reconciliation) skip themselves.
+
+3. **Note the diff size and base branch from the PR JSON.** No local branch math — `gh pr diff` returns the merged-base-to-head diff directly. Do not try to check the PR out locally; you are reviewing the diff, not running it.
+
 ### Phase 2: Create the PR
+
+**Skip this phase entirely in reviewer-mode** — the PR already exists, you did not author it, and rewriting someone else's PR body is out of scope. Proceed to Phase 3.
 
 1. **Check for an existing PR:**
    ```bash
@@ -96,7 +121,7 @@ For non-trivial PRs, write a plain-language walkthrough: one paragraph of domain
 
 ### Phase 3: Architectural Review
 
-Consult `review-checklist.md` for the review dimensions and their violation patterns.
+Consult `review-checklist.md` for the review dimensions and their violation patterns. The 10 dimensions run identically in both modes — the `diff` they read is the local `git diff "$BASE_BRANCH...HEAD"` in author-mode and the `gh pr diff <pr-number>` output in reviewer-mode.
 
 **Small diff** (< 200 changed lines, < 10 files): run all dimensions sequentially in the main agent.
 
@@ -124,7 +149,9 @@ Combine findings from all dimensions (or sub-agents).
 
 **Minimum-findings guard.** Before presenting, count the total findings across all three tiers. If the total is fewer than 4 on a diff of any meaningful size (more than ~50 changed lines or more than 2 files), do one more focused pass explicitly looking for what you might be missing — scope drift, silent assumption changes, shallow modules, tests that only cover the happy path, or new state files that slipped past dimension 3. A count of zero or one on a non-trivial diff is a signal that the review stopped too early, not that the code is flawless. If after the second pass the count is still low, present what you have — do not fabricate findings to hit a quota.
 
-Present in the terminal using three tiers:
+**Author-mode** prints terminal advisories (below). **Reviewer-mode** transforms those same findings into draft PR comment text (see "Reviewer-mode comment drafts" below) — same dimensions, same severity classification, different output shape.
+
+Present in the terminal using three tiers (author-mode):
 
 ```
 ## Architectural Review
@@ -176,16 +203,72 @@ Omit any tier that has zero findings.
 
 Substitute `<pr-number>` with the PR created in Phase 2. Skip the line when the work was a clean execution of a pre-shaped plan with no surprises, rework, or non-obvious decisions — the issue body and PR description already carry that record, and a `docs/solutions/` entry with no reusable lesson trains future readers to skim. When in doubt, skip. Signals that a lesson is worth capturing: a tricky bug whose root cause was non-obvious, a Rabbit Hole from the PRD that actually bit, an architectural decision with significant tradeoffs, or a pattern that should be reused. See `/compound`'s "When NOT to Use" for the full skip list.
 
+### Reviewer-mode comment drafts
+
+In reviewer-mode, transform the dimension findings into PR comment text per `references/comment-craft.md`. Output drafts to the terminal (clearly grouped) for the user to review and post — do **not** post comments directly via `gh pr comment` or `gh api` from this skill. The user is the editor of last resort; auto-posting comments on someone else's PR is hard-to-reverse and skips the human empathy pass that comment-craft is built around.
+
+For each finding, draft the comment using these rules. The full methodology is in `references/comment-craft.md`; this is the application:
+
+1. **Run the 5P gate per finding.** If the concern is unjustifiable, *Pass* (drop it from the draft set). If it is valid but out of scope for this PR, *Postpone* (surface as a "Suggested follow-up issue" line, not a PR comment). Only Propose-class findings become PR comments.
+
+2. **Map severity → Comment Signal.** Use `review-checklist.md`'s severity classification to pick the prefix:
+   - `Concern` → `needs change:` (small fix), `needs rework:` (major refactor), or `align:` (convention violation)
+   - `Suggestion` → `levelup:` (non-blocking improvement)
+   - `Observation` → either drop entirely (no action implied) or post as `nitpick:` if it warrants noting
+
+3. **Use Triple-R for action-requiring comments** (any blocking signal, plus most `levelup:`s). Request (transformation verb), Rationale (objective justification — cite the principle from `review-checklist.md`, the `.d.ts` line, the prior PR), Result (measurable end state).
+
+4. **Apply tone discipline.** Replace sentence-initial "you" with "we." Ask, don't command. Target the artifact, not the author.
+
+5. **Anchor each comment to a file path and line.** A PR comment without a code anchor is harder to act on than a terminal advisory; reuse the file/line citations the dimension findings already require (especially Surgical Scope's "cited hunks, not yes/no" rule).
+
+Output shape in the terminal:
+
+```
+## Reviewer-Mode Draft Comments — PR #<pr-number>
+
+### Per-line comments (paste at the cited code position)
+
+#### `path/to/file.ts:42`
+**`needs change:` Move helper into existing utility module**
+
+**Rationale** — the new `formatBillDate` in `src/pipeline/format.ts:42` duplicates `lib/dates/format.ts`'s shape. `pre-merge/review-checklist.md` Dim 1 (Deep Modules) flags this as information leakage between two modules holding the same protocol detail.
+
+**Result** — `formatBillDate` lives in `lib/dates/format.ts` and `src/pipeline/format.ts:42` imports it.
+
+---
+
+[next per-line comment]
+
+### Top-level review summary (paste as PR-level comment)
+
+[2-3 sentence summary of the review posture, naming the dimensions that ran and the highest-severity finding. Frame as collaborative, not adversarial — Rigby's "shippable code, not a defect tally."]
+
+### Suggested follow-up issues (5P-Postpone — do not post in this PR)
+
+- [Title] — out of scope for this PR; file as `<repo>/issues/new` if the team wants to track it
+- [Title] — same
+
+### Held back at 5P-Pass (no comments posted)
+
+- [One-line note per dropped concern with the reason — kept for the user's audit, not for the PR]
+```
+
+If after the 5P gate the per-line comment count is zero, the review may still produce a top-level approval comment — phrase it as collaborative ("ready to ship from a structural standpoint" rather than "LGTM"). Tacke notes that LGTM-only approvals are a code-review failure mode; if you ran the 10 dimensions and have nothing concrete to say, that result is meaningful and should at least name which dimensions were checked.
+
+If a disagreement is anticipated (e.g., the finding overturns a deliberate choice the author made), draft a single comment opening the MMG Exchange offline ("Can we sync briefly on the X tradeoff before I leave detailed comments?") rather than posting an objection thread on the PR.
+
 ## What This Skill is NOT
 
 - **Not a test runner.** Pre-commit hooks run tests, typecheck, and lint on every commit.
 - **Not a bug finder.** `/qa` files behavioral bugs as GitHub issues.
 - **Not a refactoring planner.** `/request-refactor-plan` produces RFC-style refactor proposals.
 - **Not a CI gate.** Findings are advisory. The user decides what to address before merging.
+- **Not an auto-poster.** Reviewer-mode produces draft comment text for the user to review and post; the skill does not call `gh pr comment` or `gh pr review` itself.
 
 ## Handoff
 
-- **Expected input:** verified implementation work that is ready for review and PR creation
-- **Produces:** a PR with lineage plus an architectural review readout
+- **Expected input:** verified implementation work that is ready for review and PR creation (author-mode), or an existing PR number you want reviewed (reviewer-mode)
+- **Produces:** a PR with lineage plus an architectural review readout (author-mode), or draft PR comment text following `references/comment-craft.md` (reviewer-mode)
 - **May redirect:** to `/qa` when a finding looks behavioral, or to `/request-refactor-plan` when deeper structural cleanup is warranted
-- **Comes next by default:** merge. Then `/compound` only when a durable lesson emerged worth capturing in `docs/solutions/` — skip it when the work was a clean execution of a pre-shaped plan
+- **Comes next by default:** merge. Then `/compound` only when a durable lesson emerged worth capturing in `docs/solutions/` — skip it when the work was a clean execution of a pre-shaped plan. In reviewer-mode, the user reviews and posts the draft comments; the next step is the author's response, not `/compound`

--- a/pre-merge/references/comment-craft.md
+++ b/pre-merge/references/comment-craft.md
@@ -1,0 +1,141 @@
+# Comment Craft
+
+Used by `/pre-merge` when running in reviewer-mode (`--pr <number>`). Author-mode `/pre-merge` produces terminal advisories on your own branch; reviewer-mode produces *PR comment text* on someone else's branch. Comment text is read by another developer in the heat of a review thread, so its craft matters separately from the architectural judgment carried by `review-checklist.md`.
+
+This doc captures the convergent comment-craft methodology from three independent sources: Tacke (*Looks Good to Me*, 2024), Rigby et al. (*Convergent Contemporary Software Peer Review Practices*, 2013), and Cohen et al. (*Best Kept Secrets of Peer Code Review*, 2006). Where the books converge, the rule is treated as load-bearing. Where they diverge, the call-out is named.
+
+## The Three-E Standard
+
+Tacke's rubric for whether a review is functioning:
+
+- **Effective** — catches what automation cannot: maintainability, architectural fit, domain convention, intent vs. implementation. The 10 dimensions in `review-checklist.md` cover this axis.
+- **Empathetic** — feedback targets the artifact, not the author. Reviews that feel like personal attacks discourage future participation and corrupt the process into theatrical agreement.
+- **Effortless** — automation and structure remove mechanical friction (formatting, lint, test pass) before human attention. Reviewer attention is finite; spending it on the computable leaves less for judgment work only humans can do.
+
+`/pre-merge`'s 10 architectural dimensions handle Effective. Pre-commit hooks and CI handle Effortless. **Comment craft is what fills the Empathetic axis.** The rest of this doc is how.
+
+## The 5P pre-comment gate
+
+Before writing any comment, run it through 5P. Skipping this step is how reviewers leak preference-as-requirement into PR threads.
+
+1. **Pause** — do not start typing. Read the hunk one more time.
+2. **Ponder** — can you state an objective justification (a fact, convention, principle, prior PR, or measurement)? Or is this a personal preference?
+3. **Pass** — if you cannot justify the comment to yourself in one sentence, do not post it. The 5P "Pass" path is the cost of passing through the gate; most preference-as-requirement comments fail here.
+4. **Propose** — objective justification exists *and* the concern is in scope for this PR → write the comment using Triple-R.
+5. **Postpone** — objective justification exists *but* the concern is out of scope → file a follow-up issue or add to the team backlog. Do not post in this PR.
+
+The Postpone path is the pressure valve for review creep. Without it, reviewers inject scope because they have nowhere else to put the idea. Use it generously.
+
+## Triple-R for action-requiring comments
+
+Every comment that requests a change should carry three properties:
+
+1. **Request** — one sentence with a *transformation verb* stating what to do. Tacke cites research showing transformation verbs (rename, remove, consolidate, expand, fix, rewrite, move, extract, inline) are statistically more prevalent in comments rated as useful; non-state-change verbs dominate nonuseful comments.
+2. **Rationale** — one to two sentences of objective justification. Cite the principle, the prior PR, the convention, or the measurement.
+3. **Result** — the measurable end state. What the code looks like after, or the metric that should hit. The author should know when the comment is satisfied.
+
+Without Result, comments produce follow-up exchange after follow-up exchange because neither side knows when it is done.
+
+**Example (Triple-R applied):**
+
+> **Request** — Can we move `authenticateUser` into `lib/auth/`? \
+> **Rationale** — Similar methods already live there; `pre-merge/review-checklist.md` Dimension 1 (Deep Modules) discourages export surface that grows without colocation, and PRs #134 and #147 set the precedent. \
+> **Result** — `authenticateUser` is exported from `lib/auth/index.ts` and the call site here imports from there.
+
+## Comment Signals — blocking semantics
+
+Tacke's signal system for the author. Tacke explicitly recommends this *over* MoSCoW (Must/Should/Could/Would) because Must/Should and Could/Would boundaries blur in practice and produce meta-debates about category choice instead of code substance.
+
+| Signal           | Blocking? | Meaning                          |
+| ---------------- | --------- | -------------------------------- |
+| `needs change:`  | Yes       | small fix                        |
+| `needs rework:`  | Yes       | major refactor                   |
+| `align:`         | Yes       | convention violation             |
+| `levelup:`       | No        | encouraged for future PR         |
+| `nitpick:`       | No        | purely subjective — never blocks |
+
+Rules:
+
+- **Every action-requiring comment carries a signal prefix.** Authors should not have to guess whether a comment blocks merge.
+- **`nitpick:` never blocks a PR.** This is pre-agreed; do not debate it in the review.
+- **`levelup:` is the natural pair to 5P-Postpone.** If the suggestion is valid but out of scope, prefer Postpone (file a follow-up); use `levelup:` when the suggestion is small and lives well as a non-blocking comment on this PR.
+
+Map back to `review-checklist.md` severity tiers when transcribing terminal findings into PR comments:
+
+- **Concern** → `needs change:` or `needs rework:`, depending on size; `align:` when the violation is convention-rooted
+- **Suggestion** → `levelup:`
+- **Observation** → either skip the comment entirely (no action implied) or post as `nitpick:` if it warrants noting
+
+## Tone discipline — pronoun swaps and "ask, don't command"
+
+Politeness in code review is not a cultural norm — it is backed by linguistic research. Tacke cites Ferreira et al.'s study on detecting interpersonal conflict in code review: the second-person pronoun "you" is statistically more likely to appear in toxic comments, especially sentence-initial. Technical terms ("test," "files," "pull request") are almost nonexistent in toxic comments.
+
+Two operationalizations:
+
+1. **Replace sentence-initial "you" with "we."** Shifts responsibility from individual to team and reinforces shared codebase ownership. "You should move the `Vehicle` class out of this file" → "Can we move the `Vehicle` class into its own module?"
+2. **Ask, don't command.** "Can we consider…" rather than "Change this to…" The question form preserves specificity while removing the directive structure.
+
+The structural commitment underneath both is **"You Are Not Your Code"**: code review feedback targets the artifact, never the author. The same concern can be delivered as direct (specific, objective, artifact-targeted) or blunt (personal, demoralizing, author-targeted) — the 5P gate filters for objectivity, the pronoun swap filters for tone, and both are required.
+
+## MMG Exchange — when reviewer and author disagree
+
+When both sides hold opposing "objective" positions, continuing to exchange comments in the PR produces a public argument with no resolution mechanism. Tacke's **Maintainable Middle Ground (MMG) Exchange** routes the dispute offline:
+
+1. **Acknowledge tone.** Either side can call a pause if the thread is escalating.
+2. **Understand each other's reasoning.** A short synchronous conversation (DM, call, or in-person) where each side states what they think the other is optimizing for. Often dissolves the disagreement entirely — the two sides were optimizing for different invariants and didn't know it.
+3. **Find middle ground.** A solution both sides can defend, not a compromise that satisfies neither.
+4. **Escalate to team if no middle ground exists.** A senior or domain owner adjudicates. The tiebreaker rule: **the solution most readable and maintainable to future developers wins**, not the solution either party prefers.
+
+Skipping offline escalation stalls the PR indefinitely and damages the relationship for future reviews. The PR comment thread is not a dispute resolution channel; it is a public record of the resolution.
+
+## Stance — collaborative problem-solving, not defect counting
+
+Rigby's evidence (across Apache, Linux, AMD, and other large open-source and enterprise projects) is that the goal of review is **shippable code, not a defect tally**. AMD's defect-recording fields collapsed to ~87% zero-defect when the team's posture shifted from "find as many bugs as possible" to "two developers converging on a working change."
+
+Three implications for `/pre-merge` reviewer-mode:
+
+- **No defect counts in comments.** Do not include "found N issues" preambles. Surface the substantive findings.
+- **Frame Concerns as collaborative resolution targets.** "We need to address X before merge" beats "this is broken." Both can be objective; only the first preserves the working relationship.
+- **Cohen's Big Brother Effect — do not weaponize metrics.** If the project tracks review metrics (response time, comment count, defect classification), do not use those metrics to evaluate individuals. Tracking-as-pressure produces theatrical reviews and corrupts the data being collected.
+
+## Author preparation — when reviewing your own author-mode work
+
+This doc is reviewer-side, but Cohen's Author Preparation principle informs author-mode `/pre-merge` too: before requesting review, the author should annotate the diff (rationale, risky areas, deliberate non-changes) so the reviewer's first read is informed. Author-mode `/pre-merge`'s PR body template (see `SKILL.md`'s "PR body template" section, particularly the "plain-language walkthrough" requirement that defers to `references/writing-for-humans.md`) already operationalizes this — the walkthrough *is* the author preparation.
+
+## Quick reference — the comment loop
+
+```
+Spot something in the diff
+    │
+    ▼
+5P gate ──► Pass (do not post)
+    │
+    ├──► Postpone (file follow-up issue)
+    │
+    └──► Propose
+            │
+            ▼
+       Triple-R draft
+       (Request + Rationale + Result)
+            │
+            ▼
+       Add Comment Signal prefix
+       (needs change: | needs rework: | align: | levelup: | nitpick:)
+            │
+            ▼
+       Tone pass
+       ("you" → "we", command → ask)
+            │
+            ▼
+       Post comment
+
+Disagreement? → MMG Exchange (offline) → record outcome in PR
+```
+
+## Sources
+
+- Tacke, *Looks Good to Me* (Manning, 2024) — Three-E Standard, 5P, Triple-R, Comment Signals, MMG Exchange, pronoun research, "You Are Not Your Code." Primary source for this doc.
+- Rigby & Bird, *Convergent Contemporary Software Peer Review Practices* (FSE, 2013) — collaborative problem-solving stance over defect tally; AMD's zero-defect collapse evidence.
+- Cohen, Teleki, Brown, *Best Kept Secrets of Peer Code Review* (SmartBear, 2006) — Author Preparation, Big Brother Effect on metrics.
+
+All three are loadable via `/library`.

--- a/pre-merge/review-checklist.md
+++ b/pre-merge/review-checklist.md
@@ -1,6 +1,8 @@
 # Review Checklist
 
-Used by `/pre-merge` during Phase 3. Eight dimensions, each independent. For every finding, classify as Observation, Suggestion, or Concern using the severity rules at the bottom.
+Used by `/pre-merge` during Phase 3 in both author-mode and reviewer-mode. Eight dimensions, each independent. For every finding, classify as Observation, Suggestion, or Concern using the severity rules at the bottom.
+
+In **reviewer-mode** (`/pre-merge --pr <number>`), findings here become PR comment drafts via `references/comment-craft.md` — the severity tier maps onto a Comment Signal prefix (`Concern` → `needs change:` / `needs rework:` / `align:`, `Suggestion` → `levelup:`, `Observation` → drop or `nitpick:`) and each blocking comment is shaped through Triple-R. The dimensions and severity rules below are unchanged across modes; comment-craft only governs how the findings are presented to the author.
 
 ---
 

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -282,7 +282,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/write-a-prd` | Validated research plus shaping context | Shaped PRD issue with appetite, rabbit holes, no-gos | `/prd-to-issues` (may invoke `/design-an-interface`) |
 | `/prd-to-issues` | Shaped PRD issue | Slice issues with boundary maps and dependency order | `/execute` |
 | `/execute` | Concrete slice or task with enough scope clarity | Verified commits, one per logical unit | `/pre-merge` (auto-invoked after Step 5 PR-review confirmation) |
-| `/pre-merge` | Verified implementation ready to review | PR with lineage plus architectural review readout | Merge, then `/compound` only when a durable lesson emerged |
+| `/pre-merge` | Verified implementation ready to review (author-mode), or an existing PR number to review (reviewer-mode via `--pr <n>`) | PR with lineage plus architectural review readout (author-mode), or draft PR comment text shaped by `references/comment-craft.md` (reviewer-mode) | Merge, then `/compound` only when a durable lesson emerged |
 | `/compound` | Shipped work or meaningful lesson from review or QA | `docs/solutions/` entry with volatility and Shelf Life | Future `/research` and `/write-a-prd` consult it |
 | `/api-design-review` | API-shaped uncertainty from `/research` or `/write-a-prd` | Contract verdict, compatibility class, must-lock decisions | Returns to the calling skill |
 | `/design-an-interface` | Module problem with multiple plausible shapes | Contrasted interface options with a recommendation | Returns to caller (usually `/write-a-prd`) |


### PR DESCRIPTION
## Summary

`/pre-merge` was author-side only: when someone else opened a PR, Skill Kit had no native review surface, and reviewers reached for platform `/review` or invented comment conventions every time. The architectural-review side of code review was strong (10 dimensions, severity tiers, "verify, don't suspect"), but the *human-collaboration* side — comment craft — was missing entirely. Tacke (*Looks Good to Me*), Rigby (*Convergent Contemporary Software Peer Review*), and Cohen (*Best Kept Secrets of Peer Code Review*) all converge on it as the bigger half of review work; none of that lived in this repo.

This PR closes the asymmetry without adding a new direct-entry skill. `/pre-merge` now has two modes: **author-mode** (default, unchanged behavior — auto-invoked from `/execute` Step 6, creates the PR, prints terminal advisories) and **reviewer-mode** (`/pre-merge --pr <n>` — fetches the target PR via `gh`, runs the same 10 architectural dimensions on its diff, and produces *draft comment text* the user reviews and posts). The dimensions and severity tiers are the same in both modes; only Phase 4's output shape changes.

The new `pre-merge/references/comment-craft.md` carries the methodology that converts findings into comments: the **Three-E Standard** (Effective / Empathetic / Effortless), the **5P pre-comment gate** (Pause / Ponder / Pass / Propose / Postpone), the **Triple-R** shape for action-requiring comments (Request + Rationale + Result), **Comment Signals** for blocking semantics (`needs change:`, `needs rework:`, `align:`, `levelup:`, `nitpick:`), tone discipline (sentence-initial "you" → "we", ask-don't-command, "You Are Not Your Code"), and the **MMG Exchange** for moving disputes offline before a public PR thread stalls indefinitely. Severity tiers in `review-checklist.md` map onto Comment Signals, so the review machinery doesn't fork — the reviewer just translates.

Why it matters: code review is a two-sided activity, and a reviewer-mode toggle plus a one-page methodology reference is the smallest coherent change that fills the Empathetic axis of the Three-E Standard without eroding the boundary against `/qa`, `/triage-issue`, or `/improve-codebase-architecture`. The skill explicitly does not auto-post comments — drafting on someone else's PR is reversible only by the user, and skipping the human empathy pass is exactly the failure mode comment-craft is built around.

## PRD

Closes #44

## Slices

This PR was not decomposed via `/prd-to-issues` — issue #44 is an `/improve-pipeline` proposal with a single coherent change set (one new reference file, one skill body update, three cross-reference touches). All four commits ship as one logical unit:

- `ea92de4` add(pre-merge): comment-craft reference for reviewer-mode
- `023c7d3` update(pre-merge): add reviewer-mode for someone else's PR
- `ed8b7ed` update(pre-merge): cross-reference reviewer-mode + comment-craft
- `a709420` sync(skills): propagate SYSTEM-OVERVIEW.md update to bundled copies

## Key Decisions

- **Reviewer-mode is a flag on `/pre-merge`, not a sibling skill.** The 10 architectural dimensions are genuinely shared between author-side and reviewer-side use; spinning a separate `/review-pr` would have duplicated or imported most of `/pre-merge`. The Mediator Verdict in #44 weighed this against the Skeptic's "shallow modules" concern and chose mode-flag over duplication.
- **Skill produces draft comment text; never auto-posts.** Auto-posting on someone else's PR is hard-to-reverse and skips the empathy pass. Drafts go to the terminal grouped by anchor (per-line / top-level / 5P-Postpone / 5P-Pass-held-back).
- **No changes to the 10 dimensions or severity tiers.** Comment-craft governs *how findings are presented*; what counts as a finding is unchanged.
- **No defect-tracking fields or metrics.** Rigby's evidence against defect-recording (Big Brother Effect, AMD's zero-defect-rate collapse when posture shifts) stands.