### PR TITLE
Allow contract-shape code in PRDs; reference rather than re-render in slices (#52)

### DIFF
--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -63,6 +63,33 @@ For each slice, specify:
 - **Consumes from #N:** What this slice needs from upstream slices — specific imports, API endpoints it calls, types it uses. Reference the producing slice by number. If the parent PRD's research lives in a `research`-labeled spike issue (see `/research` Phase 5d), you may also cite `Refs #<spike-issue-number>` here when the slice's interface decisions are bounded by a specific recommendation, callback contract, or version snapshot recorded in that spike. The `Refs #N` lineage syntax is the same one used elsewhere in the pipeline.
 - **Contract notes:** The success shape, error shape, compatibility posture, and any versioning readiness concerns that matter to downstream consumers.
 
+**Contract-shape rendering.** When the parent PRD locks a schema, type alias, function signature, or structured input/output shape in code form (per `/write-a-prd`'s Implementation Decisions guidance), the slice's `Produces` field should reference it by location rather than re-render it. Re-render only when the slice introduces a contract shape the PRD did not lock. This keeps the PRD as the single source of truth for locked contracts and avoids drift between two surface forms of the same artifact.
+
+Example — when the PRD's Implementation Decisions block locks a Drizzle schema:
+
+```ts
+// PRD #47 §Implementation Decisions
+export const dramaAssessments = sqliteTable("drama_assessments", {
+  id: integer().primaryKey({ autoIncrement: true }),
+  meetingId: integer("meeting_id").notNull().references(() => meetings.id),
+  level: text().notNull(), // "routine" | "bumpy" | "heated" | "off-the-rails"
+  confidence: real().notNull(),
+  promptVersion: text("prompt_version").notNull(),
+  model: text().notNull(),
+  headline: text().notNull(),
+  narrative: text().notNull(),
+  evidenceQuotes: text("evidence_quotes", { mode: "json" }).$type<string[]>().notNull(),
+  publishedAt: integer("published_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().default(sql`(unixepoch())`),
+}, (t) => [uniqueIndex("drama_assessments_meeting_prompt_model_unique").on(t.meetingId, t.promptVersion, t.model)]);
+```
+
+…the slice's `Produces` should read:
+
+> - `src/db/schema.ts` — adds `dramaAssessments` and `dramaCategoryScores` tables per PRD #47 §Implementation Decisions. No re-render here; consume the PRD's contract shape verbatim.
+
+If the slice introduces additional types not locked by the PRD (e.g. an internal `DramaLevel` union the schema's `level` column will be narrowed to in TS), render those in the slice's `Produces` as the slice is the owning home.
+
 The boundary map prevents the most common multi-slice failure: slices that are each internally correct but don't actually wire together because they made incompatible assumptions about interfaces.
 
 **Orthogonality test:** After drafting the boundary map, check each slice: if this slice's internal implementation changed entirely, would any other slice need to change? If yes, the boundary is drawn wrong — either merge the coupled slices, or extract the shared concern into its own slice. Slices that pass this test can be implemented in any order by Ralph without risk of one slice's decisions breaking another.

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -68,7 +68,7 @@ For each slice, specify:
 Example — when the PRD's Implementation Decisions block locks a Drizzle schema:
 
 ```ts
-// PRD #47 §Implementation Decisions
+// PRD #<prd-issue-number> §Implementation Decisions
 export const dramaAssessments = sqliteTable("drama_assessments", {
   id: integer().primaryKey({ autoIncrement: true }),
   meetingId: integer("meeting_id").notNull().references(() => meetings.id),
@@ -86,7 +86,7 @@ export const dramaAssessments = sqliteTable("drama_assessments", {
 
 …the slice's `Produces` should read:
 
-> - `src/db/schema.ts` — adds `dramaAssessments` and `dramaCategoryScores` tables per PRD #47 §Implementation Decisions. No re-render here; consume the PRD's contract shape verbatim.
+> - `src/db/schema.ts` — adds `dramaAssessments` and `dramaCategoryScores` tables per PRD #<prd-issue-number> §Implementation Decisions. No re-render here; consume the PRD's contract shape verbatim.
 
 If the slice introduces additional types not locked by the PRD (e.g. an internal `DramaLevel` union the schema's `level` column will be narrowed to in TS), render those in the slice's `Produces` as the slice is the owning home.
 

--- a/write-a-prd/SKILL.md
+++ b/write-a-prd/SKILL.md
@@ -286,7 +286,9 @@ A list of implementation decisions that were made. This can include:
 - API contracts
 - Specific interactions
 
-Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+Do NOT include implementation snippets — loop bodies, error handling, helper function internals, configuration string literals. These drift the moment the builder makes a judgment call.
+
+DO render **locked contract shapes** in code form when the PRD's decision lives at the surface level: schema column lists (Drizzle, Prisma, SQL DDL), exported type aliases or interfaces, exported function signatures, structured input/output schemas (Zod, JSON Schema). The test is empirical: if a downstream pipeline step (`/prd-to-issues` Boundary Map, `/execute` Consumes verification, `/pre-merge` boundary-contract review) will grep for this identifier or shape, it is a contract shape and belongs in code. If no downstream step will inherit it verbatim, it is an implementation detail and stays prose or stays out. Contract-shape code drifts at the same rate as the PRD's renegotiation path — edit the PRD body and regenerate the Coverage Matrix, the same flow used for any other PRD content change.
 
 ## Research Reference
 


### PR DESCRIPTION
## Summary

`/write-a-prd`'s §Implementation Decisions template carried a categorical "no code snippets" prohibition that was producing prose-shaped schemas in PRDs. When a PRD locks a Drizzle table or a Zod shape, the next reader can read the prose but cannot scan it — they have to mentally render it before they can verify house-style fit, nullability, or unique-index column ordering. `/prd-to-issues` was working around the prohibition by re-rendering the same schema in code at slice time, which created a new failure mode: which version of the contract is canonical, the PRD's prose or the slice's code?

This PR refines the upstream rule rather than strengthening the downstream workaround. The new rule splits the original prohibition into two classes: implementation snippets (loop bodies, error handling, helper internals, config string literals) remain prohibited because they drift the moment the builder makes a judgment call; locked contract shapes (schema column lists, type aliases, exported function signatures, structured I/O schemas) are now welcome in code form because they are part of what the PRD is locking and downstream pipeline steps inherit them verbatim. The boundary between the two is empirical, not stylistic — "would `/prd-to-issues` Boundary Map, `/execute` Consumes verification, or `/pre-merge` boundary-contract review grep for this identifier?" If yes, code; if no, prose or out.

`/prd-to-issues` §Boundary Map gets a paired update: when the PRD has already locked a contract shape in code, the slice's `Produces` field references it by location rather than re-rendering it. A short Drizzle example shows what that looks like end-to-end. The slice's `Produces` still owns any contract shape the PRD did not lock — the change does not push synthesis upstream, it just stops the re-render cycle when the PRD is already authoritative.

The library citation is Norman, *Design of Everyday Things* — knowledge in the world vs. in the head. Prose schemas keep the contract in the head; code blocks put it in the world. Hunt & Thomas's "knowledge in plain text" is the secondary support: a Drizzle block is plain text the next reader can grep, diff, and copy; prose describing the same schema is plain text only in form.

## PRD

Closes #52

## Slices

This is a single-PRD, single-slice change — the issue is a `/improve-pipeline` proposal targeting `chrislacey89/skills` itself, not a multi-slice feature.

## Key Decisions

- **Refine, don't strengthen.** The original "no code snippets" rule was right about implementation snippets and wrong about contract shapes; bundling them into one prohibition over-restricted the contract class. The fix is the carve-out, not a new clause on the downstream skill.
- **Empirical boundary, not stylistic.** The Skeptic case in #52 warned that "contract shape vs. implementation snippet" is fuzzy at the edges. The carve-out's sharp test ("will a downstream pipeline step grep for this identifier verbatim?") makes the boundary checkable instead of negotiable.
- **Slice points at PRD by default; re-renders only when introducing new shape.** This preserves single-source-of-truth for locked contracts and avoids the two-surface drift the issue identified.
- **Concrete Drizzle example over abstract guidance.** The example block intentionally matches `civic-mirror`'s `src/db/schema.ts` house style — `sqliteTable`, snake_case column names + camelCase JS keys, `unixepoch()` defaults, `uniqueIndex` placement — because the field incident the issue documents was a `civic-mirror` PRD, and the example will be the first thing future readers pattern-match against.