### PR TITLE
Fork /prototype and add FEASIBILITY branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ When modifying a skill:
 - If a skill reconnects to the main pipeline, say exactly where it reconnects
 - If a skill advances an issue through lifecycle states, define those states and the minimum content required to move between them
 - If a skill can run HITL or AFK, say which mode is expected by default and what durable artifacts must exist before AFK execution is safe
+- Use American English spelling throughout: *behavior* not *behaviour*, *color* not *colour*, *initialize* not *initialise*, *center* not *centre*, *optimize* not *optimise*, *neighbor* not *neighbour*, etc. When forking an upstream skill that uses British spelling, convert it in the same change. Exceptions: proper nouns, book titles, and quoted material keep their original spelling.
 
 ## Shared reference files
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Skill Kit
 
 [![License: MIT](https://img.shields.io/github/license/chrislacey89/skills)](LICENSE)
-![Skills](https://img.shields.io/badge/skills-23-blue)
+![Skills](https://img.shields.io/badge/skills-24-blue)
 ![CLI](https://img.shields.io/badge/npx%20skills-compatible-green)
 
-Skill Kit is a pipeline-first Claude Code skills pack for structured feature delivery. 23 composable skills that take a feature from idea to shipped — with explicit handoffs, verified research, and a compounding knowledge loop.
+Skill Kit is a pipeline-first Claude Code skills pack for structured feature delivery. 24 composable skills that take a feature from idea to shipped — with explicit handoffs, verified research, and a compounding knowledge loop.
 
 Built around structured research, GitHub-native state, and a compounding knowledge loop in `docs/solutions/`. Compatible with Claude Code, Cursor, Windsurf, and any agent that can consume SKILL.md files.
 
@@ -53,6 +53,7 @@ The pipeline is the default path, not a prison. Skills can backtrack when assump
 | [prd-to-issues](prd-to-issues/) | Break PRD into vertical slices with boundary maps |
 | [design-an-interface](design-an-interface/) | Generate multiple radically different interface designs |
 | [api-design-review](api-design-review/) | Focused contract review for higher-risk API design decisions |
+| [prototype](prototype/) | Throwaway code that answers a question — LOGIC (state model), UI (layout variants), or FEASIBILITY (spike-solution discharge for `Uncertain` research assumptions) |
 
 ### Development
 

--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -289,6 +289,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/tdd` | Concrete behavior ready for red-green-refactor | Tested code increments via vertical cycles | Returns to caller (usually `/execute`) |
 | `/qa` | Observed user-facing failures or regressions — single entry for bug conversations | Durable GitHub bug issues in domain language; delegates per-issue to `/triage-issue` for deep bugs | `/execute` (or per-issue to `/triage-issue`) |
 | `/triage-issue` | Single bug delegated from `/qa`'s depth check, needing diagnosis before implementation | Root-cause issue with TDD fix plan, replacing the lightweight `/qa` issue for that bug. Built on a Zeller-style spine: deterministic feedback loop first, ranked falsifiable hypotheses, then a seam check that hands off to `/improve-codebase-architecture` when no correct test seam exists | Returns to the `/qa` loop, then `/execute` (often via `/tdd`), or `/improve-codebase-architecture` when the seam check fails |
+| `/prototype` | One question that needs throwaway code to answer — a state model to feel out (LOGIC), a layout to compare variants of (UI), or an `Uncertain` assumption to discharge with a focused spike (FEASIBILITY) | Captured answer in the calling skill's durable artifact (research assumption tag, ADR, commit message, NOTES.md) and the spike code deleted in the same change | Returns to the caller (usually `/research` for FEASIBILITY, or the user for LOGIC / UI) |
 | `/request-refactor-plan` | Refactor problem needing safer sequencing | GitHub issue with tiny-commit refactor plan | `/execute` |
 | `/improve-codebase-architecture` | Architectural friction, coupled modules, shallow pain | Candidate deepening opportunities and a refactor RFC | `/request-refactor-plan` or `/execute` |
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
@@ -305,7 +306,8 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 
 - `/shape` → `/research` for work that fits a single PRD, or `/create-milestone` for work that requires multiple independent PRDs
 - `/create-milestone` → selected feature issue promoted from `roadmap bet` to `research-ready`, then `/research`
-- `/research` → `/write-a-prd` and conditionally `/api-design-review`
+- `/research` → `/write-a-prd` and conditionally `/api-design-review`; when an `Uncertain` assumption is cheaply code-verifiable, `/research` names `/prototype` FEASIBILITY as the discharge route before handoff
+- `/prototype` — kit-owned side-route with three branches (LOGIC for state models, UI for layout variants, FEASIBILITY for spike-solution feasibility verdicts). FEASIBILITY is named by `/research` (Phase 4 / Phase 6) and `/execute` (Step 0 advisory) as the discharge route for un-discharged `Uncertain` assumptions; the verdict folds back into the calling artifact and the spike code is deleted in the same change
 - `/write-a-prd` → `/prd-to-issues` (with optional container milestone for big-batch work) and conditionally `/design-an-interface` or `/api-design-review`
 - `/init-pipeline` is auto-invoked by `/execute` Step 0 when `.claude/hooks/enforce-classification.sh` is missing — scaffolds Claude Code hooks (TDD classification gate, git guardrails), pre-commit hooks, and package manager enforcement
 - `/setup-ralph-loop` is auto-invoked by `/execute` when the task comes from a multi-slice GitHub issue and no Ralph scripts exist — prepares `ralph-once.sh` and bounded `ralph.sh` for HITL-to-AFK execution
@@ -362,6 +364,11 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 │  ── SIDE ROUTES AND SUPPORTING PATHS ──────────────────────────────────
 │
 ├── qa/SKILL.md                     # Single entry point for bug conversations — files lightweight issues and delegates per-issue to /triage-issue when depth is needed
+├── prototype/                      # Kit-owned fork of Matt Pocock's /prototype with a third FEASIBILITY branch (spike-solution discharge for /research Uncertain assumptions)
+│   ├── SKILL.md
+│   ├── LOGIC.md
+│   ├── UI.md
+│   └── FEASIBILITY.md
 ├── improve-codebase-architecture/  # Find deepening opportunities and spin them into refactor work
 │   ├── SKILL.md
 │   └── REFERENCE.md
@@ -416,6 +423,8 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Start a new feature | `/shape` to establish what to build, then hand off to `/research` |
 | Plan a blank project or major tranche | `/shape`, then `/create-milestone` if the work requires multiple independent PRDs. If it fits one PRD (even if big-batch), stay on the default path — `/write-a-prd` creates a container milestone |
 | Research the technical approach | `/research` (always runs, depth auto-calibrated, invokes `/api-design-review` for higher-risk API contract work, then hands off to `/write-a-prd`) |
+| Verify a technical assumption before committing | `/prototype` FEASIBILITY — write a focused spike (one automated test, or a scratch route when visual confirmation is required), capture the verdict in the calling artifact (e.g. downgrade an `Uncertain` tag in the research doc), delete the spike in the same change |
+| Feel out a state model or compare layout variants | `/prototype` LOGIC (terminal app over a pure reducer/state machine) or `/prototype` UI (radically different variants on one route, switchable from a floating bar) |
 | Promote a milestone feature into the pipeline | Expand the selected feature issue from `roadmap bet` to `research-ready`, then run `/research` |
 | Write a shaped pitch | `/write-a-prd` → shaped pitch filed as GitHub issue (appetite → solution → rabbit holes → no-gos, includes API contract sketch when relevant, auto-invokes `/design-an-interface` or `/api-design-review` when needed, then hands off to `/prd-to-issues`) |
 | Break into work items | `/prd-to-issues` → GitHub issues with boundary maps that feed `/execute`; Ralph can run the AFK loop over unblocked issues |

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -289,6 +289,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/tdd` | Concrete behavior ready for red-green-refactor | Tested code increments via vertical cycles | Returns to caller (usually `/execute`) |
 | `/qa` | Observed user-facing failures or regressions — single entry for bug conversations | Durable GitHub bug issues in domain language; delegates per-issue to `/triage-issue` for deep bugs | `/execute` (or per-issue to `/triage-issue`) |
 | `/triage-issue` | Single bug delegated from `/qa`'s depth check, needing diagnosis before implementation | Root-cause issue with TDD fix plan, replacing the lightweight `/qa` issue for that bug. Built on a Zeller-style spine: deterministic feedback loop first, ranked falsifiable hypotheses, then a seam check that hands off to `/improve-codebase-architecture` when no correct test seam exists | Returns to the `/qa` loop, then `/execute` (often via `/tdd`), or `/improve-codebase-architecture` when the seam check fails |
+| `/prototype` | One question that needs throwaway code to answer — a state model to feel out (LOGIC), a layout to compare variants of (UI), or an `Uncertain` assumption to discharge with a focused spike (FEASIBILITY) | Captured answer in the calling skill's durable artifact (research assumption tag, ADR, commit message, NOTES.md) and the spike code deleted in the same change | Returns to the caller (usually `/research` for FEASIBILITY, or the user for LOGIC / UI) |
 | `/request-refactor-plan` | Refactor problem needing safer sequencing | GitHub issue with tiny-commit refactor plan | `/execute` |
 | `/improve-codebase-architecture` | Architectural friction, coupled modules, shallow pain | Candidate deepening opportunities and a refactor RFC | `/request-refactor-plan` or `/execute` |
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
@@ -305,7 +306,8 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 
 - `/shape` → `/research` for work that fits a single PRD, or `/create-milestone` for work that requires multiple independent PRDs
 - `/create-milestone` → selected feature issue promoted from `roadmap bet` to `research-ready`, then `/research`
-- `/research` → `/write-a-prd` and conditionally `/api-design-review`
+- `/research` → `/write-a-prd` and conditionally `/api-design-review`; when an `Uncertain` assumption is cheaply code-verifiable, `/research` names `/prototype` FEASIBILITY as the discharge route before handoff
+- `/prototype` — kit-owned side-route with three branches (LOGIC for state models, UI for layout variants, FEASIBILITY for spike-solution feasibility verdicts). FEASIBILITY is named by `/research` (Phase 4 / Phase 6) and `/execute` (Step 0 advisory) as the discharge route for un-discharged `Uncertain` assumptions; the verdict folds back into the calling artifact and the spike code is deleted in the same change
 - `/write-a-prd` → `/prd-to-issues` (with optional container milestone for big-batch work) and conditionally `/design-an-interface` or `/api-design-review`
 - `/init-pipeline` is auto-invoked by `/execute` Step 0 when `.claude/hooks/enforce-classification.sh` is missing — scaffolds Claude Code hooks (TDD classification gate, git guardrails), pre-commit hooks, and package manager enforcement
 - `/setup-ralph-loop` is auto-invoked by `/execute` when the task comes from a multi-slice GitHub issue and no Ralph scripts exist — prepares `ralph-once.sh` and bounded `ralph.sh` for HITL-to-AFK execution
@@ -362,6 +364,11 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 │  ── SIDE ROUTES AND SUPPORTING PATHS ──────────────────────────────────
 │
 ├── qa/SKILL.md                     # Single entry point for bug conversations — files lightweight issues and delegates per-issue to /triage-issue when depth is needed
+├── prototype/                      # Kit-owned fork of Matt Pocock's /prototype with a third FEASIBILITY branch (spike-solution discharge for /research Uncertain assumptions)
+│   ├── SKILL.md
+│   ├── LOGIC.md
+│   ├── UI.md
+│   └── FEASIBILITY.md
 ├── improve-codebase-architecture/  # Find deepening opportunities and spin them into refactor work
 │   ├── SKILL.md
 │   └── REFERENCE.md
@@ -416,6 +423,8 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Start a new feature | `/shape` to establish what to build, then hand off to `/research` |
 | Plan a blank project or major tranche | `/shape`, then `/create-milestone` if the work requires multiple independent PRDs. If it fits one PRD (even if big-batch), stay on the default path — `/write-a-prd` creates a container milestone |
 | Research the technical approach | `/research` (always runs, depth auto-calibrated, invokes `/api-design-review` for higher-risk API contract work, then hands off to `/write-a-prd`) |
+| Verify a technical assumption before committing | `/prototype` FEASIBILITY — write a focused spike (one automated test, or a scratch route when visual confirmation is required), capture the verdict in the calling artifact (e.g. downgrade an `Uncertain` tag in the research doc), delete the spike in the same change |
+| Feel out a state model or compare layout variants | `/prototype` LOGIC (terminal app over a pure reducer/state machine) or `/prototype` UI (radically different variants on one route, switchable from a floating bar) |
 | Promote a milestone feature into the pipeline | Expand the selected feature issue from `roadmap bet` to `research-ready`, then run `/research` |
 | Write a shaped pitch | `/write-a-prd` → shaped pitch filed as GitHub issue (appetite → solution → rabbit holes → no-gos, includes API contract sketch when relevant, auto-invokes `/design-an-interface` or `/api-design-review` when needed, then hands off to `/prd-to-issues`) |
 | Break into work items | `/prd-to-issues` → GitHub issues with boundary maps that feed `/execute`; Ralph can run the AFK loop over unblocked issues |

--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -105,6 +105,8 @@ If all assumptions still hold, proceed to Step 1. If any assumption has changed,
 
 Skip this gate entirely for one-off tasks without an "Assumptions from Parent PRD" section.
 
+**Un-discharged feasibility check (advisory).** If the task's research artifact (archive file or spike issue) still carries `Uncertain` or `Speculative` assumptions whose verdicts are cheaply settled by 10 lines of throwaway code — does the library actually expose this, does the streaming path emit partial tags, does this format render where we need it — surface them now and suggest `/prototype` FEASIBILITY before main implementation. This is advisory, not blocking (per XP's *slack* principle); the user may have a reason to proceed and discover the answer mid-implementation. But the cost asymmetry is real (XP's *Defect Cost Increase*): a spike at this moment costs minutes, while the same assumption discovered mid-implementation costs hours of pivot. State the un-discharged assumptions explicitly and let the user decide. Skip this check for one-off tasks without a research artifact or when every assumption is already tagged `Verified` / `Refuted`.
+
 **Consumes verification gate.** Only for issue-based slice work. If the task comes from a GitHub issue created by `/prd-to-issues`, and its `## Boundary Map` / `### Consumes` section references an already-closed upstream slice, spend 60 seconds verifying each listed symbol exists at the declared path in the current tree. This catches upstream boundary-map drift before implementation starts.
 
 For each Consumes entry:

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -289,6 +289,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/tdd` | Concrete behavior ready for red-green-refactor | Tested code increments via vertical cycles | Returns to caller (usually `/execute`) |
 | `/qa` | Observed user-facing failures or regressions — single entry for bug conversations | Durable GitHub bug issues in domain language; delegates per-issue to `/triage-issue` for deep bugs | `/execute` (or per-issue to `/triage-issue`) |
 | `/triage-issue` | Single bug delegated from `/qa`'s depth check, needing diagnosis before implementation | Root-cause issue with TDD fix plan, replacing the lightweight `/qa` issue for that bug. Built on a Zeller-style spine: deterministic feedback loop first, ranked falsifiable hypotheses, then a seam check that hands off to `/improve-codebase-architecture` when no correct test seam exists | Returns to the `/qa` loop, then `/execute` (often via `/tdd`), or `/improve-codebase-architecture` when the seam check fails |
+| `/prototype` | One question that needs throwaway code to answer — a state model to feel out (LOGIC), a layout to compare variants of (UI), or an `Uncertain` assumption to discharge with a focused spike (FEASIBILITY) | Captured answer in the calling skill's durable artifact (research assumption tag, ADR, commit message, NOTES.md) and the spike code deleted in the same change | Returns to the caller (usually `/research` for FEASIBILITY, or the user for LOGIC / UI) |
 | `/request-refactor-plan` | Refactor problem needing safer sequencing | GitHub issue with tiny-commit refactor plan | `/execute` |
 | `/improve-codebase-architecture` | Architectural friction, coupled modules, shallow pain | Candidate deepening opportunities and a refactor RFC | `/request-refactor-plan` or `/execute` |
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
@@ -305,7 +306,8 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 
 - `/shape` → `/research` for work that fits a single PRD, or `/create-milestone` for work that requires multiple independent PRDs
 - `/create-milestone` → selected feature issue promoted from `roadmap bet` to `research-ready`, then `/research`
-- `/research` → `/write-a-prd` and conditionally `/api-design-review`
+- `/research` → `/write-a-prd` and conditionally `/api-design-review`; when an `Uncertain` assumption is cheaply code-verifiable, `/research` names `/prototype` FEASIBILITY as the discharge route before handoff
+- `/prototype` — kit-owned side-route with three branches (LOGIC for state models, UI for layout variants, FEASIBILITY for spike-solution feasibility verdicts). FEASIBILITY is named by `/research` (Phase 4 / Phase 6) and `/execute` (Step 0 advisory) as the discharge route for un-discharged `Uncertain` assumptions; the verdict folds back into the calling artifact and the spike code is deleted in the same change
 - `/write-a-prd` → `/prd-to-issues` (with optional container milestone for big-batch work) and conditionally `/design-an-interface` or `/api-design-review`
 - `/init-pipeline` is auto-invoked by `/execute` Step 0 when `.claude/hooks/enforce-classification.sh` is missing — scaffolds Claude Code hooks (TDD classification gate, git guardrails), pre-commit hooks, and package manager enforcement
 - `/setup-ralph-loop` is auto-invoked by `/execute` when the task comes from a multi-slice GitHub issue and no Ralph scripts exist — prepares `ralph-once.sh` and bounded `ralph.sh` for HITL-to-AFK execution
@@ -362,6 +364,11 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 │  ── SIDE ROUTES AND SUPPORTING PATHS ──────────────────────────────────
 │
 ├── qa/SKILL.md                     # Single entry point for bug conversations — files lightweight issues and delegates per-issue to /triage-issue when depth is needed
+├── prototype/                      # Kit-owned fork of Matt Pocock's /prototype with a third FEASIBILITY branch (spike-solution discharge for /research Uncertain assumptions)
+│   ├── SKILL.md
+│   ├── LOGIC.md
+│   ├── UI.md
+│   └── FEASIBILITY.md
 ├── improve-codebase-architecture/  # Find deepening opportunities and spin them into refactor work
 │   ├── SKILL.md
 │   └── REFERENCE.md
@@ -416,6 +423,8 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Start a new feature | `/shape` to establish what to build, then hand off to `/research` |
 | Plan a blank project or major tranche | `/shape`, then `/create-milestone` if the work requires multiple independent PRDs. If it fits one PRD (even if big-batch), stay on the default path — `/write-a-prd` creates a container milestone |
 | Research the technical approach | `/research` (always runs, depth auto-calibrated, invokes `/api-design-review` for higher-risk API contract work, then hands off to `/write-a-prd`) |
+| Verify a technical assumption before committing | `/prototype` FEASIBILITY — write a focused spike (one automated test, or a scratch route when visual confirmation is required), capture the verdict in the calling artifact (e.g. downgrade an `Uncertain` tag in the research doc), delete the spike in the same change |
+| Feel out a state model or compare layout variants | `/prototype` LOGIC (terminal app over a pure reducer/state machine) or `/prototype` UI (radically different variants on one route, switchable from a floating bar) |
 | Promote a milestone feature into the pipeline | Expand the selected feature issue from `roadmap bet` to `research-ready`, then run `/research` |
 | Write a shaped pitch | `/write-a-prd` → shaped pitch filed as GitHub issue (appetite → solution → rabbit holes → no-gos, includes API contract sketch when relevant, auto-invokes `/design-an-interface` or `/api-design-review` when needed, then hands off to `/prd-to-issues`) |
 | Break into work items | `/prd-to-issues` → GitHub issues with boundary maps that feed `/execute`; Ralph can run the AFK loop over unblocked issues |

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -289,6 +289,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/tdd` | Concrete behavior ready for red-green-refactor | Tested code increments via vertical cycles | Returns to caller (usually `/execute`) |
 | `/qa` | Observed user-facing failures or regressions — single entry for bug conversations | Durable GitHub bug issues in domain language; delegates per-issue to `/triage-issue` for deep bugs | `/execute` (or per-issue to `/triage-issue`) |
 | `/triage-issue` | Single bug delegated from `/qa`'s depth check, needing diagnosis before implementation | Root-cause issue with TDD fix plan, replacing the lightweight `/qa` issue for that bug. Built on a Zeller-style spine: deterministic feedback loop first, ranked falsifiable hypotheses, then a seam check that hands off to `/improve-codebase-architecture` when no correct test seam exists | Returns to the `/qa` loop, then `/execute` (often via `/tdd`), or `/improve-codebase-architecture` when the seam check fails |
+| `/prototype` | One question that needs throwaway code to answer — a state model to feel out (LOGIC), a layout to compare variants of (UI), or an `Uncertain` assumption to discharge with a focused spike (FEASIBILITY) | Captured answer in the calling skill's durable artifact (research assumption tag, ADR, commit message, NOTES.md) and the spike code deleted in the same change | Returns to the caller (usually `/research` for FEASIBILITY, or the user for LOGIC / UI) |
 | `/request-refactor-plan` | Refactor problem needing safer sequencing | GitHub issue with tiny-commit refactor plan | `/execute` |
 | `/improve-codebase-architecture` | Architectural friction, coupled modules, shallow pain | Candidate deepening opportunities and a refactor RFC | `/request-refactor-plan` or `/execute` |
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
@@ -305,7 +306,8 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 
 - `/shape` → `/research` for work that fits a single PRD, or `/create-milestone` for work that requires multiple independent PRDs
 - `/create-milestone` → selected feature issue promoted from `roadmap bet` to `research-ready`, then `/research`
-- `/research` → `/write-a-prd` and conditionally `/api-design-review`
+- `/research` → `/write-a-prd` and conditionally `/api-design-review`; when an `Uncertain` assumption is cheaply code-verifiable, `/research` names `/prototype` FEASIBILITY as the discharge route before handoff
+- `/prototype` — kit-owned side-route with three branches (LOGIC for state models, UI for layout variants, FEASIBILITY for spike-solution feasibility verdicts). FEASIBILITY is named by `/research` (Phase 4 / Phase 6) and `/execute` (Step 0 advisory) as the discharge route for un-discharged `Uncertain` assumptions; the verdict folds back into the calling artifact and the spike code is deleted in the same change
 - `/write-a-prd` → `/prd-to-issues` (with optional container milestone for big-batch work) and conditionally `/design-an-interface` or `/api-design-review`
 - `/init-pipeline` is auto-invoked by `/execute` Step 0 when `.claude/hooks/enforce-classification.sh` is missing — scaffolds Claude Code hooks (TDD classification gate, git guardrails), pre-commit hooks, and package manager enforcement
 - `/setup-ralph-loop` is auto-invoked by `/execute` when the task comes from a multi-slice GitHub issue and no Ralph scripts exist — prepares `ralph-once.sh` and bounded `ralph.sh` for HITL-to-AFK execution
@@ -362,6 +364,11 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 │  ── SIDE ROUTES AND SUPPORTING PATHS ──────────────────────────────────
 │
 ├── qa/SKILL.md                     # Single entry point for bug conversations — files lightweight issues and delegates per-issue to /triage-issue when depth is needed
+├── prototype/                      # Kit-owned fork of Matt Pocock's /prototype with a third FEASIBILITY branch (spike-solution discharge for /research Uncertain assumptions)
+│   ├── SKILL.md
+│   ├── LOGIC.md
+│   ├── UI.md
+│   └── FEASIBILITY.md
 ├── improve-codebase-architecture/  # Find deepening opportunities and spin them into refactor work
 │   ├── SKILL.md
 │   └── REFERENCE.md
@@ -416,6 +423,8 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Start a new feature | `/shape` to establish what to build, then hand off to `/research` |
 | Plan a blank project or major tranche | `/shape`, then `/create-milestone` if the work requires multiple independent PRDs. If it fits one PRD (even if big-batch), stay on the default path — `/write-a-prd` creates a container milestone |
 | Research the technical approach | `/research` (always runs, depth auto-calibrated, invokes `/api-design-review` for higher-risk API contract work, then hands off to `/write-a-prd`) |
+| Verify a technical assumption before committing | `/prototype` FEASIBILITY — write a focused spike (one automated test, or a scratch route when visual confirmation is required), capture the verdict in the calling artifact (e.g. downgrade an `Uncertain` tag in the research doc), delete the spike in the same change |
+| Feel out a state model or compare layout variants | `/prototype` LOGIC (terminal app over a pure reducer/state machine) or `/prototype` UI (radically different variants on one route, switchable from a floating bar) |
 | Promote a milestone feature into the pipeline | Expand the selected feature issue from `roadmap bet` to `research-ready`, then run `/research` |
 | Write a shaped pitch | `/write-a-prd` → shaped pitch filed as GitHub issue (appetite → solution → rabbit holes → no-gos, includes API contract sketch when relevant, auto-invokes `/design-an-interface` or `/api-design-review` when needed, then hands off to `/prd-to-issues`) |
 | Break into work items | `/prd-to-issues` → GitHub issues with boundary maps that feed `/execute`; Ralph can run the AFK loop over unblocked issues |

--- a/prototype/FEASIBILITY.md
+++ b/prototype/FEASIBILITY.md
@@ -22,7 +22,7 @@ Kent Beck's *Defect Cost Increase* names the cost curve directly: the longer an 
 
 XP's *test-first programming* operates self-similarly: TDD at the minute scale, FEASIBILITY spike at the assumption scale, themes at the quarter scale. FEASIBILITY is the assumption-scale rung — the spike *is* the question made executable, the verdict *is* the test's outcome, and the spike is deleted once the verdict is captured.
 
-Hunt & Thomas's distinction in *The Pragmatic Programmer* helps locate this against neighbouring shapes: **tracer bullets** are real-but-minimal end-to-end implementations that stay in the codebase; **prototypes** (LOGIC and UI in this skill) are throwaway code that explores a design question; **feasibility spikes** sit between — throwaway like a prototype, real-API like a tracer bullet, scoped to a single yes/no question. Beck's *spike solution* is the canonical primary name for the activity; tracer-bullet contrast is the supporting clarification.
+Hunt & Thomas's distinction in *The Pragmatic Programmer* helps locate this against neighboring shapes: **tracer bullets** are real-but-minimal end-to-end implementations that stay in the codebase; **prototypes** (LOGIC and UI in this skill) are throwaway code that explores a design question; **feasibility spikes** sit between — throwaway like a prototype, real-API like a tracer bullet, scoped to a single yes/no question. Beck's *spike solution* is the canonical primary name for the activity; tracer-bullet contrast is the supporting clarification.
 
 ## Process
 
@@ -112,7 +112,7 @@ The spike-solution narrowness defines what this branch refuses to cover:
 - **Spikes that grow features.** A spike that gains a second assertion, a third configuration, or a "while I'm here" tweak has stopped being a spike. Delete it and start over with a tighter question.
 - **Spikes that survive the change.** The deletion is part of the work, not a follow-up. A spike file on `main` after the verdict has been captured is a smell.
 - **Verdicts without questions.** "It works" is not a verdict. The verdict is the answer to *the question stated in step 1*. Without the question, the answer has no meaning to the next reader.
-- **Spikes for questions the docs already answer.** Read the docs first. Spike only when the docs are silent, ambiguous, or contradicted by behaviour. Otherwise the spike is busywork — a confirmation ritual that costs more than reading.
+- **Spikes for questions the docs already answer.** Read the docs first. Spike only when the docs are silent, ambiguous, or contradicted by behavior. Otherwise the spike is busywork — a confirmation ritual that costs more than reading.
 - **Spikes that wrap mocks.** A spike against a mocked library proves nothing about the real library. Hit the real surface.
 
 ## Related terminology

--- a/prototype/FEASIBILITY.md
+++ b/prototype/FEASIBILITY.md
@@ -1,0 +1,125 @@
+# Feasibility Prototype
+
+A focused **spike solution** that gives a binary verdict on whether a single technical assumption holds. Use this when the only honest answer to a question is "let's run it and see," and the question is small enough that a 10-line throwaway test can settle it.
+
+The vocabulary is Kent Beck's. From *Extreme Programming Explained*: a spike solution is **a small program written to explore the answer to a technical question, then thrown away**. The spike is not the feature; it's the question made executable.
+
+If the question is "what does this shape feel like?" — wrong branch. Use [LOGIC.md](LOGIC.md). If the question is "what should this look like?" — wrong branch. Use [UI.md](UI.md).
+
+## When this is the right shape
+
+- An `Uncertain` (or `Speculative`) assumption surfaced in a `/research` artifact that explicitly recommends a spike to discharge.
+- A library claim that can't be confirmed by reading docs alone — does the streaming path actually emit partial tags, does the SDK accept this header, does this format render where we need it to.
+- A version-specific behavior question — does the installed version still expose the API we're planning to call.
+- A renderer / parser / format compatibility question — does this content survive a round-trip through the toolchain.
+- A binary precondition for a PRD — if the answer is "no," the PRD changes. If the answer is "yes," nothing changes.
+
+The defining signal: **one question, two possible verdicts, code is the cheapest evidence**. If you find yourself drafting more than one question, split the spike — one verdict per spike, no exceptions.
+
+## Why this branch exists
+
+Kent Beck's *Defect Cost Increase* names the cost curve directly: the longer an unverified assumption survives, the more expensive its eventual contradiction. An `Uncertain` assumption discharged at `/research` time costs minutes (a 10-line spike). The same assumption discovered at `/execute` time costs hours of mid-implementation pivot. After merge, it costs a retrospective, a rewrite, or both.
+
+XP's *test-first programming* operates self-similarly: TDD at the minute scale, FEASIBILITY spike at the assumption scale, themes at the quarter scale. FEASIBILITY is the assumption-scale rung — the spike *is* the question made executable, the verdict *is* the test's outcome, and the spike is deleted once the verdict is captured.
+
+Hunt & Thomas's distinction in *The Pragmatic Programmer* helps locate this against neighbouring shapes: **tracer bullets** are real-but-minimal end-to-end implementations that stay in the codebase; **prototypes** (LOGIC and UI in this skill) are throwaway code that explores a design question; **feasibility spikes** sit between — throwaway like a prototype, real-API like a tracer bullet, scoped to a single yes/no question. Beck's *spike solution* is the canonical primary name for the activity; tracer-bullet contrast is the supporting clarification.
+
+## Process
+
+### 1. State the question and the two possible verdicts
+
+Before writing any spike code, write down — in one sentence each — the question and what each verdict would mean.
+
+> **Question:** Does Streamdown render a custom `<book>` XML tag inline mid-paragraph without breaking surrounding prose?
+> **If yes:** PRD proceeds as drafted, assumption tag downgrades from `Uncertain` to `Verified`.
+> **If no:** PRD must pivot to a different inline-rendering primitive; flag for `/correct-course` from `/research`.
+
+A spike whose verdicts both lead to "we'll figure it out" is not a feasibility question; it's a design exploration in disguise. Send it to LOGIC or UI instead.
+
+### 2. Pick the artifact shape
+
+Two shapes, picked by what kind of evidence is cheapest:
+
+#### Shape A — Automated test (preferred default)
+
+Write **one focused test** using the project's existing test runner — Vitest, Jest, pytest, RSpec, whatever the host project uses. The test exercises the real library or system, asserts the expected behavior, and emits a pass/fail verdict.
+
+Pick this when:
+
+- The behavior is verifiable programmatically (string output, exit code, return value, structural shape).
+- The library or system can be exercised from a test environment.
+- The verdict is binary and machine-checkable.
+
+This is the default. Reach for Shape B only when visual confirmation is genuinely required.
+
+#### Shape B — Temporary scratch route (visual-confirmation case)
+
+Mount a **single throwaway route** (or page, screen, endpoint) that exercises the real system in a way the user can eyeball. Use whatever routing convention the project already uses; don't invent a new top-level structure. Name it so a casual reader can see it's a spike.
+
+Pick this only when:
+
+- The verdict requires visual judgment (does this *look* right when rendered, does this animation actually play, does this layout reflow as expected).
+- A test runner can't observe the behavior cheaply (e.g., browser rendering, native UI, video frames).
+
+Shape B exists because some verdicts genuinely need eyeballs. Most don't — if a test can answer it, write the test.
+
+### 3. Write the spike
+
+Whichever shape, hold the spike to these rules:
+
+- **Real library, real version.** Import from the installed package, hit the real API surface. Mocks defeat the spike's purpose.
+- **One assertion or one observable outcome.** Multiple assertions widen the question. Keep the spike scoped to the single verdict.
+- **Minimal scaffolding.** No fixtures, no helpers, no shared setup beyond what the test runner or framework forces. The spike is read once and deleted; brevity beats reuse.
+- **No production code paths.** The spike doesn't import from app code or live alongside it as if it were a fixture. It exists in a clearly throwaway location (e.g. `spike-<question-slug>.test.ts` colocated with the area the question concerns, or `app/spike-<slug>/page.tsx` for Shape B).
+
+### 4. Run it and capture the verdict
+
+Run the spike. Read the output. Decide which verdict fired.
+
+Capture the verdict somewhere durable **before** deleting the spike. Three lines is enough — the question, the verdict, and the date.
+
+For verdicts that fold back into a `/research` artifact, the canonical update is in that artifact: change the assumption's tag (`Uncertain` → `Verified` / `Refuted`), and add a one-line note citing the spike's date and the observed outcome. The research artifact is the single home for the fact — *Once and Only Once*, per Beck — so the verdict doesn't also live in a `NOTES.md` and a commit message and a chat log. If `/research` ran in spike-issue storage mode, the original spike-issue body is point-in-time and not edited; instead, the calling PRD or the new `/research` run cites the verdict and supersedes the older snapshot when the change is material.
+
+If `/research` is not the caller, capture the verdict in whatever durable artifact the calling skill names: a commit message, an ADR, a comment on the issue that triggered the spike. Wherever it lives, the *question* must be captured alongside the *verdict* — a verdict without its question is a fact without a referent and rots fast.
+
+### 5. Delete the spike
+
+Same change that captures the verdict, delete the spike code. A merged spike is a dead file pretending to be alive — future readers will assume it's a test that means something, and the cost of explaining what it means accumulates every time someone reads it.
+
+The exception: when the spike's structure happens to be a useful regression test for the verified behavior, promote it. But "promote" means rewriting it with real assertions, a real name, real coverage of edge cases, and a place in the suite that someone has signed off on — not leaving the spike in place and renaming the file. Spike code was written under spike constraints; production tests are not.
+
+### 6. Hand off back to the caller
+
+Tell the calling skill what happened:
+
+- **Verified verdict** → the calling skill's assumption tag downgrades; the original plan proceeds.
+- **Refuted verdict** → the calling skill's plan needs to change. If the caller was `/research`, this is a `/correct-course` trigger or a re-run of `/research` with the new evidence. If the caller was `/execute`'s Step 0 advisory, this is a stop-and-flag — the slice cannot proceed on stale assumptions.
+- **Ambiguous verdict** → the spike was too wide. Split the question into smaller sub-questions, pick one, write a new spike. Do not record an ambiguous result as a verified or refuted verdict.
+
+## What this branch is *not* for
+
+The spike-solution narrowness defines what this branch refuses to cover:
+
+- **Performance exploration.** "How fast is X?" is not a binary verdict; it's a measurement. Use a benchmark, not a spike.
+- **"See what happens" coding.** Open-ended exploration without a stated question is the failure mode this branch exists to prevent. State the question and the two verdicts before writing any code, or stop.
+- **Refactor exploration.** "What would this look like if we restructured it?" is a design question — use `/request-refactor-plan` or a LOGIC prototype.
+- **Multi-question spikes.** One spike, one question, one verdict. If multiple questions exist, write multiple spikes (or pick one and accept that the others stay open).
+- **Design exploration in disguise.** "Which API shape feels better?" is a LOGIC question. "Which layout reads cleaner?" is a UI question. The signal that you're in the wrong branch: more than one verdict could plausibly be "good enough" and you'd still need to choose.
+- **Standing infrastructure.** If the spike happens to be useful indefinitely, it's not a spike anymore — promote it to a real test or a real fixture in a deliberate, separate change.
+
+## Anti-patterns
+
+- **Spikes that grow features.** A spike that gains a second assertion, a third configuration, or a "while I'm here" tweak has stopped being a spike. Delete it and start over with a tighter question.
+- **Spikes that survive the change.** The deletion is part of the work, not a follow-up. A spike file on `main` after the verdict has been captured is a smell.
+- **Verdicts without questions.** "It works" is not a verdict. The verdict is the answer to *the question stated in step 1*. Without the question, the answer has no meaning to the next reader.
+- **Spikes for questions the docs already answer.** Read the docs first. Spike only when the docs are silent, ambiguous, or contradicted by behaviour. Otherwise the spike is busywork — a confirmation ritual that costs more than reading.
+- **Spikes that wrap mocks.** A spike against a mocked library proves nothing about the real library. Hit the real surface.
+
+## Related terminology
+
+The word "spike" appears in two places in Skill Kit:
+
+- **`/research`'s `spike-issue` storage mode** (configured via `.claude/settings.json` `research.storage = spike-issue`) — a GitHub-issue-shaped home for the research artifact. The storage *mode* uses "spike" in the sense of "the research result, frozen as a closed issue."
+- **This branch's spike solution** — Kent Beck's XP term for a small program that answers a technical question and then dies. The *activity*, not the artifact.
+
+Both senses are legitimate and they don't collide in practice; if terminology gets confusing in a specific repo, the [#70 meta-glossary](https://github.com/chrislacey89/skills/issues/70) is where the pinning lives.

--- a/prototype/LOGIC.md
+++ b/prototype/LOGIC.md
@@ -1,0 +1,79 @@
+# Logic Prototype
+
+A tiny interactive terminal app that lets the user drive a state model by hand. Use this when the question is about **business logic, state transitions, or data shape** — the kind of thing that looks reasonable on paper but only feels wrong once you push it through real cases.
+
+## When this is the right shape
+
+- "I'm not sure if this state machine handles the edge case where X then Y."
+- "Does this data model actually let me represent the case where..."
+- "I want to feel out what the API should look like before writing it."
+- Anything where the user wants to **press buttons and watch state change**.
+
+If the question is "what should this look like" — wrong branch. Use [UI.md](UI.md).
+
+## Process
+
+### 1. State the question
+
+Before writing code, write down what state model and what question you're prototyping. One paragraph, in the prototype's README or a comment at the top of the file. A logic prototype that answers the wrong question is pure waste — make the question explicit so it can be checked later, whether the user is watching now or returning to it AFK.
+
+### 2. Pick the language
+
+Use whatever the host project uses. If the project has no obvious runtime (e.g. a docs repo), ask.
+
+Match the project's existing conventions for tooling — don't add a new package manager or runtime just for the prototype.
+
+### 3. Isolate the logic in a portable module
+
+Put the actual logic — the bit that's answering the question — behind a small, pure interface that could be lifted out and dropped into the real codebase later. The TUI around it is throwaway; the logic module shouldn't be.
+
+The right shape depends on the question:
+
+- **A pure reducer** — `(state, action) => state`. Good when actions are discrete events and state is a single value.
+- **A state machine** — explicit states and transitions. Good when "which actions are even legal right now" is part of the question.
+- **A small set of pure functions** over a plain data type. Good when there's no implicit current state — just transformations.
+- **A class or module with a clear method surface** when the logic genuinely owns ongoing internal state.
+
+Pick whichever shape best fits the question being asked, *not* whichever is easiest to wire to a TUI. Keep it pure: no I/O, no terminal code, no `console.log` for control flow. The TUI imports it and calls into it; nothing flows the other direction.
+
+This is what makes the prototype useful past its own lifetime. When the question's been answered, the validated reducer / machine / function set can be lifted into the real module — the TUI shell gets deleted.
+
+### 4. Build the smallest TUI that exposes the state
+
+Build it as a **lightweight TUI** — on every tick, clear the screen (`console.clear()` / `print("\033[2J\033[H")` / equivalent) and re-render the whole frame. The user should always see one stable view, not an ever-growing scrollback.
+
+Each frame has two parts, in this order:
+
+1. **Current state**, pretty-printed and diff-friendly (one field per line, or formatted JSON). Use **bold** for field names or section headers and **dim** for less important context (timestamps, IDs, derived values). Native ANSI escape codes are fine — `\x1b[1m` bold, `\x1b[2m` dim, `\x1b[0m` reset. No need to pull in a styling library unless one is already in the project.
+2. **Keyboard shortcuts**, listed at the bottom: `[a] add user  [d] delete user  [t] tick clock  [q] quit`. Bold the key, dim the description, or vice-versa — whatever reads cleanly.
+
+Behaviour:
+
+1. **Initialise state** — a single in-memory object/struct. Render the first frame on start.
+2. **Read one keystroke (or one line)** at a time, dispatch to a handler that mutates state.
+3. **Re-render** the full frame after every action — don't append, replace.
+4. **Loop until quit.**
+
+The whole frame should fit on one screen.
+
+### 5. Make it runnable in one command
+
+Add a script to the project's existing task runner (`package.json` scripts, `Makefile`, `justfile`, `pyproject.toml`). The user should run `pnpm run <prototype-name>` or equivalent — never need to remember a path.
+
+If the host project has no task runner, just put the command at the top of the prototype's README.
+
+### 6. Hand it over
+
+Give the user the run command. They'll drive it themselves; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" — those are the bugs in the _idea_, which is the whole point. If they want new actions added, add them. Prototypes evolve.
+
+### 7. Capture the answer
+
+When the prototype has done its job, the answer to the question is the only thing worth keeping. If the user is around, ask what it taught them. If not, leave a `NOTES.md` next to the prototype so the answer can be filled in (or filled in by you, if you've watched the session) before the prototype gets deleted.
+
+## Anti-patterns
+
+- **Don't add tests.** A prototype that needs tests is no longer a prototype.
+- **Don't wire it to the real database.** Use an in-memory store unless the question is specifically about persistence.
+- **Don't generalise.** No "what if we wanted to support X later." The prototype answers one question.
+- **Don't blur the logic and the TUI together.** If the reducer / state machine references `console.log`, prompts, or terminal escape codes, it's no longer portable. Keep the TUI as a thin shell over a pure module.
+- **Don't ship the TUI shell into production.** The shell is optimised for being driven by hand from a terminal. The logic module behind it is the bit worth keeping.

--- a/prototype/LOGIC.md
+++ b/prototype/LOGIC.md
@@ -47,9 +47,9 @@ Each frame has two parts, in this order:
 1. **Current state**, pretty-printed and diff-friendly (one field per line, or formatted JSON). Use **bold** for field names or section headers and **dim** for less important context (timestamps, IDs, derived values). Native ANSI escape codes are fine — `\x1b[1m` bold, `\x1b[2m` dim, `\x1b[0m` reset. No need to pull in a styling library unless one is already in the project.
 2. **Keyboard shortcuts**, listed at the bottom: `[a] add user  [d] delete user  [t] tick clock  [q] quit`. Bold the key, dim the description, or vice-versa — whatever reads cleanly.
 
-Behaviour:
+Behavior:
 
-1. **Initialise state** — a single in-memory object/struct. Render the first frame on start.
+1. **Initialize state** — a single in-memory object/struct. Render the first frame on start.
 2. **Read one keystroke (or one line)** at a time, dispatch to a handler that mutates state.
 3. **Re-render** the full frame after every action — don't append, replace.
 4. **Loop until quit.**
@@ -74,6 +74,6 @@ When the prototype has done its job, the answer to the question is the only thin
 
 - **Don't add tests.** A prototype that needs tests is no longer a prototype.
 - **Don't wire it to the real database.** Use an in-memory store unless the question is specifically about persistence.
-- **Don't generalise.** No "what if we wanted to support X later." The prototype answers one question.
+- **Don't generalize.** No "what if we wanted to support X later." The prototype answers one question.
 - **Don't blur the logic and the TUI together.** If the reducer / state machine references `console.log`, prompts, or terminal escape codes, it's no longer portable. Keep the TUI as a thin shell over a pure module.
-- **Don't ship the TUI shell into production.** The shell is optimised for being driven by hand from a terminal. The logic module behind it is the bit worth keeping.
+- **Don't ship the TUI shell into production.** The shell is optimized for being driven by hand from a terminal. The logic module behind it is the bit worth keeping.

--- a/prototype/SKILL.md
+++ b/prototype/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: prototype
+description: Build a throwaway prototype to flush out a question before committing to it. Routes between three branches — a runnable terminal app for state/business-logic questions (LOGIC), several radically different UI variations toggleable from one route (UI), or a focused spike that gives a binary verdict on whether a technical assumption holds (FEASIBILITY). Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, verify an `Uncertain` assumption from `/research` before `/write-a-prd`, or says "prototype this", "let me play with it", "try a few designs", "spike this", "can the library actually do X", or "is this feasible".
+sources:
+  primary:
+    - "Extreme Programming Explained — Kent Beck"
+  secondary:
+    - "The Pragmatic Programmer — Andrew Hunt & David Thomas"
+    - "The Design of Everyday Things — Don Norman"
+---
+
+# Prototype
+
+A prototype is **throwaway code that answers a question**. The question decides the shape.
+
+> **Forked from Matt Pocock's `/prototype` on 2026-05-11; kit-owned for iteration.** The LOGIC and UI branches are unchanged from upstream. The FEASIBILITY branch is a kit addition so `/research` and `/execute` can name a discharge route for `Uncertain` assumptions that are cheaply verifiable by code.
+
+## Pick a branch
+
+Identify which question is being answered — from the user's prompt, the surrounding code, or by asking if the user is around:
+
+- **"Does this logic / state model feel right?"** → [LOGIC.md](LOGIC.md). Build a tiny interactive terminal app that pushes the state machine through cases that are hard to reason about on paper.
+- **"What should this look like?"** → [UI.md](UI.md). Generate several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+- **"Does this approach actually work?"** → [FEASIBILITY.md](FEASIBILITY.md). Write a focused spike — one automated test or a temporary scratch route — that gives a binary verdict on whether a single technical assumption holds. Then delete the spike and fold the verdict into the calling skill's artifact.
+
+The three branches produce very different artifacts — getting this wrong wastes the whole prototype. The clearest signal:
+
+- If the question is about *which shape feels right* (state model, layout, API ergonomics), pick LOGIC or UI.
+- If the question is *yes-or-no on a technical assumption* (does the library expose this, does this configuration survive the streaming path, does this format render where we need it), pick FEASIBILITY.
+
+If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch better matches the surrounding code (a backend module → LOGIC; a page or component → UI; an `Uncertain` assumption in a research artifact → FEASIBILITY) and state the assumption at the top of the prototype.
+
+## Rules that apply to all branches
+
+1. **Throwaway from day one, and clearly marked as such.** Locate the prototype code close to where it will actually be used (next to the module or page it's prototyping for) so context is obvious — but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; don't invent a new top-level structure.
+2. **One command to run.** Whatever the project's existing task runner supports — `pnpm <name>`, `python <path>`, `bun <path>`, `pnpm run test <file>`, etc. The user must be able to start it without thinking.
+3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is *checking*, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
+4. **Skip the polish.** No tests beyond the spike's own assertion (FEASIBILITY only), no error handling beyond what makes the prototype *runnable*, no abstractions. The point is to learn something fast and then delete it.
+5. **Surface the state or the verdict.** LOGIC re-renders state after every action; UI shows the variant on every switch; FEASIBILITY emits a pass/fail verdict from the test runner or a single observable outcome from the scratch route.
+6. **Delete or absorb when done.** When the prototype has answered its question, either delete it or fold the validated decision into the real code — don't leave it rotting in the repo. For FEASIBILITY specifically, the spike is deleted in the same change that captures the verdict; the verdict is what persists, not the spike.
+
+## When done
+
+The *answer* is the only thing worth keeping from a prototype. Capture it somewhere durable (commit message, ADR, issue, the research artifact's assumption tag, or a `NOTES.md` next to the prototype) along with the question it was answering. If the user is around, that capture is a quick conversation; if not, leave the placeholder so they (or you, on the next pass) can fill in the verdict before deleting the prototype.
+
+For FEASIBILITY spikes specifically, the verdict folds back into the calling skill's artifact: `/research` downgrades the assumption tag (e.g. `Uncertain` → `Verified` or `Refuted`), and `/execute` proceeds, pivots, or files a `/correct-course` depending on the answer.

--- a/prototype/UI.md
+++ b/prototype/UI.md
@@ -1,0 +1,112 @@
+# UI Prototype
+
+Generate **several radically different UI variations** on a single route, switchable from a floating bottom bar. The user flips between variants in the browser, picks one (or steals bits from each), then throws the rest away.
+
+If the question is about logic/state rather than what something looks like — wrong branch. Use [LOGIC.md](LOGIC.md).
+
+## When this is the right shape
+
+- "What should this page look like?"
+- "I want to see a few options for this dashboard before committing."
+- "Try a different layout for the settings screen."
+- Any time the user would otherwise spend a day picking between three vague mockups in their head.
+
+## Two sub-shapes — strongly prefer sub-shape A
+
+A UI prototype is much easier to judge when it's **butting up against the rest of the app** — real header, real sidebar, real data, real density. A throwaway route on its own is a vacuum: every variant looks fine in isolation. Default to sub-shape A whenever there's a plausible existing page to host the variants. Only reach for sub-shape B if the prototype genuinely has no nearby home.
+
+### Sub-shape A — adjustment to an existing page (preferred)
+
+The route already exists. Variants are rendered **on the same route**, gated by a `?variant=` URL search param. The existing data fetching, params, and auth all stay — only the rendering swaps. This is the default; pick it unless there's a specific reason not to.
+
+If the prototype is for something that doesn't yet have a page but *would naturally live inside one* (a new section of the dashboard, a new card on the settings screen, a new step in an existing flow) — that's still sub-shape A. Mount the variants inside the host page.
+
+### Sub-shape B — a new page (last resort)
+
+Only use this when the thing being prototyped genuinely has no existing page to live inside — e.g. an entirely new top-level surface, or a flow that can't be embedded anywhere sensible.
+
+Create a **throwaway route** following whatever routing convention the project already uses — don't invent a new top-level structure. Name it so it's obviously a prototype (e.g. include the word `prototype` in the path or filename). Same `?variant=` pattern.
+
+Before committing to sub-shape B, sanity-check: is there really no existing page this could be embedded in? An empty route hides design problems that a populated one would expose.
+
+In both sub-shapes the floating bottom bar is identical.
+
+## Process
+
+### 1. State the question and pick N
+
+Default to **3 variants**. More than 5 stops being radically different and starts being noise — cap there.
+
+Write down the plan in one line, in the prototype's location or a top-of-file comment:
+
+> "Three variants of the settings page, switchable via `?variant=`, on the existing `/settings` route."
+
+This works whether the user is here to push back or not.
+
+### 2. Generate radically different variants
+
+Draft each variant. Hold each one to:
+
+- The page's purpose and the data it has access to.
+- The project's component library / styling system (TailwindCSS, shadcn, MUI, plain CSS, whatever).
+- A clear exported component name, e.g. `VariantA`, `VariantB`, `VariantC`.
+
+Variants must be **structurally different** — different layout, different information hierarchy, different primary affordance, not just different colours. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
+
+### 3. Wire them together
+
+Create a single switcher component on the route:
+
+```tsx
+// pseudo-code — adapt to the project's framework
+const variant = searchParams.get('variant') ?? 'A';
+return (
+  <>
+    {variant === 'A' && <VariantA {...data} />}
+    {variant === 'B' && <VariantB {...data} />}
+    {variant === 'C' && <VariantC {...data} />}
+    <PrototypeSwitcher variants={['A','B','C']} current={variant} />
+  </>
+);
+```
+
+For sub-shape A (existing page): keep all the existing data fetching above the switcher; only the rendered subtree changes per variant.
+
+For sub-shape B (new page): the throwaway route under `/prototype/<name>` mounts the same switcher.
+
+### 4. Build the floating switcher
+
+A small fixed-position bar at the bottom-centre of the screen with three pieces:
+
+- **Left arrow** — cycles to the previous variant (wraps around).
+- **Variant label** — shows the current variant key and, if the variant exports a name, that name too. e.g. `B — Sidebar layout`.
+- **Right arrow** — cycles forward (wraps around).
+
+Behaviour:
+
+- Clicking an arrow updates the URL search param (use the framework's router — `router.replace` on Next, `navigate` on React Router, etc) so the variant is shareable and reload-stable.
+- Keyboard: `←` and `→` arrow keys also cycle. Don't intercept arrow keys when an `<input>`, `<textarea>`, or `[contenteditable]` is focused.
+- Visually distinct from the page (e.g. high-contrast pill, subtle shadow) so it's obviously not part of the design being evaluated.
+- Hidden in production builds — gate on `process.env.NODE_ENV !== 'production'` or an equivalent check, so a stray prototype merge can't ship the bar to users.
+
+Put the switcher in a single shared component so both sub-shapes can reuse it. Locate it wherever shared UI lives in the project.
+
+### 5. Hand it over
+
+Surface the URL (and the `?variant=` keys). The user will flip through whenever they get to it. The interesting feedback is usually **"I want the header from B with the sidebar from C"** — that's the actual design they want.
+
+### 6. Capture the answer and clean up
+
+Once a variant has won, write down which one and why (commit message, ADR, issue, or a `NOTES.md` next to the prototype if running AFK and the user hasn't responded yet). Then:
+
+- **Sub-shape A** — delete the losing variants and the switcher; fold the winner into the existing page.
+- **Sub-shape B** — promote the winning variant to a real route, delete the throwaway route and the switcher.
+
+Don't leave variant components or the switcher lying around. They rot fast and confuse the next reader.
+
+## Anti-patterns
+
+- **Variants that differ only in colour or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
+- **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>` defeats the point. Each variant should be free to throw out the layout.
+- **Wiring variants to real mutations.** Read-only prototypes are fine. If a variant needs to mutate, point it at a stub — the question is "what should this look like", not "does the backend work".
+- **Promoting the prototype directly to production.** The variant code was written under prototype constraints (no tests, minimal error handling). Rewrite it properly when you fold it in.

--- a/prototype/UI.md
+++ b/prototype/UI.md
@@ -51,7 +51,7 @@ Draft each variant. Hold each one to:
 - The project's component library / styling system (TailwindCSS, shadcn, MUI, plain CSS, whatever).
 - A clear exported component name, e.g. `VariantA`, `VariantB`, `VariantC`.
 
-Variants must be **structurally different** — different layout, different information hierarchy, different primary affordance, not just different colours. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
+Variants must be **structurally different** — different layout, different information hierarchy, different primary affordance, not just different colors. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
 
 ### 3. Wire them together
 
@@ -76,13 +76,13 @@ For sub-shape B (new page): the throwaway route under `/prototype/<name>` mounts
 
 ### 4. Build the floating switcher
 
-A small fixed-position bar at the bottom-centre of the screen with three pieces:
+A small fixed-position bar at the bottom-center of the screen with three pieces:
 
 - **Left arrow** — cycles to the previous variant (wraps around).
 - **Variant label** — shows the current variant key and, if the variant exports a name, that name too. e.g. `B — Sidebar layout`.
 - **Right arrow** — cycles forward (wraps around).
 
-Behaviour:
+Behavior:
 
 - Clicking an arrow updates the URL search param (use the framework's router — `router.replace` on Next, `navigate` on React Router, etc) so the variant is shareable and reload-stable.
 - Keyboard: `←` and `→` arrow keys also cycle. Don't intercept arrow keys when an `<input>`, `<textarea>`, or `[contenteditable]` is focused.
@@ -106,7 +106,7 @@ Don't leave variant components or the switcher lying around. They rot fast and c
 
 ## Anti-patterns
 
-- **Variants that differ only in colour or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
+- **Variants that differ only in color or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
 - **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>` defeats the point. Each variant should be free to throw out the layout.
 - **Wiring variants to real mutations.** Read-only prototypes are fine. If a variant needs to mutate, point it at a stub — the question is "what should this look like", not "does the backend work".
 - **Promoting the prototype directly to production.** The variant code was written under prototype constraints (no tests, minimal error handling). Rewrite it properly when you fold it in.

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -217,6 +217,8 @@ Before leaving Phase 4, produce a lightweight estimation-readiness readout:
 
 The goal is not to create a scheduling ceremony. The goal is to prevent research findings from being summarized as false precision.
 
+**Discharging code-verifiable `Uncertain` assumptions.** When this phase produces an `Uncertain` (or `Speculative`) assumption whose verdict is cheaply settled by 10 lines of throwaway code — does the library actually expose this, does the streaming path emit partial tags, does this format render where we need it — name `/prototype` FEASIBILITY as the discharge route in the research document and (if appetite allows) run it before handing off to `/write-a-prd`. The verdict folds back into this artifact by downgrading the assumption tag, so the PRD inherits a verified premise instead of an unverified one. This is the assumption-scale rung of XP's test-first self-similar rhythm: TDD at the minute scale, FEASIBILITY at the assumption scale.
+
 For API-shaped work, explicitly document:
 
 - the API problem statement and impact statement
@@ -516,6 +518,8 @@ Present the research document to the user. Then walk through these review questi
 4. Where do you want to run `/write-a-prd` — **here** (continue in this session) or in a **fresh session** using the printed handoff line below?
 
 Do not present all four questions at once. Iterate on each answer until the user is satisfied. Question 4 has exactly two answers — do not improvise a third option ("not yet", "later"). If the user is not ready to proceed, return to questions 1–3 to surface what is missing.
+
+**Before handoff, name any remaining feasibility spikes.** If the document still carries `Uncertain` assumptions whose verdicts are cheaply code-verifiable and have not been discharged, list them under a short "Pending feasibility spikes" closing note and name `/prototype` FEASIBILITY as the discharge route. The PRD can still be written with those assumptions tagged — but the named discharge route makes it cheap for the next agent (or this one, in `/execute` Step 0) to settle them before mid-implementation. The cost-of-delay framing is XP's *Defect Cost Increase*: discharging at `/research` time costs minutes; the same assumption discovered at `/execute` time costs hours.
 
 In archive mode, the research file is saved outside the repo — do not commit it to git. In spike-issue mode, the research lives as a closed GitHub issue and a session-local cache copy at the archive path; do not commit the cache copy either.
 

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -289,6 +289,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/tdd` | Concrete behavior ready for red-green-refactor | Tested code increments via vertical cycles | Returns to caller (usually `/execute`) |
 | `/qa` | Observed user-facing failures or regressions — single entry for bug conversations | Durable GitHub bug issues in domain language; delegates per-issue to `/triage-issue` for deep bugs | `/execute` (or per-issue to `/triage-issue`) |
 | `/triage-issue` | Single bug delegated from `/qa`'s depth check, needing diagnosis before implementation | Root-cause issue with TDD fix plan, replacing the lightweight `/qa` issue for that bug. Built on a Zeller-style spine: deterministic feedback loop first, ranked falsifiable hypotheses, then a seam check that hands off to `/improve-codebase-architecture` when no correct test seam exists | Returns to the `/qa` loop, then `/execute` (often via `/tdd`), or `/improve-codebase-architecture` when the seam check fails |
+| `/prototype` | One question that needs throwaway code to answer — a state model to feel out (LOGIC), a layout to compare variants of (UI), or an `Uncertain` assumption to discharge with a focused spike (FEASIBILITY) | Captured answer in the calling skill's durable artifact (research assumption tag, ADR, commit message, NOTES.md) and the spike code deleted in the same change | Returns to the caller (usually `/research` for FEASIBILITY, or the user for LOGIC / UI) |
 | `/request-refactor-plan` | Refactor problem needing safer sequencing | GitHub issue with tiny-commit refactor plan | `/execute` |
 | `/improve-codebase-architecture` | Architectural friction, coupled modules, shallow pain | Candidate deepening opportunities and a refactor RFC | `/request-refactor-plan` or `/execute` |
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
@@ -305,7 +306,8 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 
 - `/shape` → `/research` for work that fits a single PRD, or `/create-milestone` for work that requires multiple independent PRDs
 - `/create-milestone` → selected feature issue promoted from `roadmap bet` to `research-ready`, then `/research`
-- `/research` → `/write-a-prd` and conditionally `/api-design-review`
+- `/research` → `/write-a-prd` and conditionally `/api-design-review`; when an `Uncertain` assumption is cheaply code-verifiable, `/research` names `/prototype` FEASIBILITY as the discharge route before handoff
+- `/prototype` — kit-owned side-route with three branches (LOGIC for state models, UI for layout variants, FEASIBILITY for spike-solution feasibility verdicts). FEASIBILITY is named by `/research` (Phase 4 / Phase 6) and `/execute` (Step 0 advisory) as the discharge route for un-discharged `Uncertain` assumptions; the verdict folds back into the calling artifact and the spike code is deleted in the same change
 - `/write-a-prd` → `/prd-to-issues` (with optional container milestone for big-batch work) and conditionally `/design-an-interface` or `/api-design-review`
 - `/init-pipeline` is auto-invoked by `/execute` Step 0 when `.claude/hooks/enforce-classification.sh` is missing — scaffolds Claude Code hooks (TDD classification gate, git guardrails), pre-commit hooks, and package manager enforcement
 - `/setup-ralph-loop` is auto-invoked by `/execute` when the task comes from a multi-slice GitHub issue and no Ralph scripts exist — prepares `ralph-once.sh` and bounded `ralph.sh` for HITL-to-AFK execution
@@ -362,6 +364,11 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 │  ── SIDE ROUTES AND SUPPORTING PATHS ──────────────────────────────────
 │
 ├── qa/SKILL.md                     # Single entry point for bug conversations — files lightweight issues and delegates per-issue to /triage-issue when depth is needed
+├── prototype/                      # Kit-owned fork of Matt Pocock's /prototype with a third FEASIBILITY branch (spike-solution discharge for /research Uncertain assumptions)
+│   ├── SKILL.md
+│   ├── LOGIC.md
+│   ├── UI.md
+│   └── FEASIBILITY.md
 ├── improve-codebase-architecture/  # Find deepening opportunities and spin them into refactor work
 │   ├── SKILL.md
 │   └── REFERENCE.md
@@ -416,6 +423,8 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Start a new feature | `/shape` to establish what to build, then hand off to `/research` |
 | Plan a blank project or major tranche | `/shape`, then `/create-milestone` if the work requires multiple independent PRDs. If it fits one PRD (even if big-batch), stay on the default path — `/write-a-prd` creates a container milestone |
 | Research the technical approach | `/research` (always runs, depth auto-calibrated, invokes `/api-design-review` for higher-risk API contract work, then hands off to `/write-a-prd`) |
+| Verify a technical assumption before committing | `/prototype` FEASIBILITY — write a focused spike (one automated test, or a scratch route when visual confirmation is required), capture the verdict in the calling artifact (e.g. downgrade an `Uncertain` tag in the research doc), delete the spike in the same change |
+| Feel out a state model or compare layout variants | `/prototype` LOGIC (terminal app over a pure reducer/state machine) or `/prototype` UI (radically different variants on one route, switchable from a floating bar) |
 | Promote a milestone feature into the pipeline | Expand the selected feature issue from `roadmap bet` to `research-ready`, then run `/research` |
 | Write a shaped pitch | `/write-a-prd` → shaped pitch filed as GitHub issue (appetite → solution → rabbit holes → no-gos, includes API contract sketch when relevant, auto-invokes `/design-an-interface` or `/api-design-review` when needed, then hands off to `/prd-to-issues`) |
 | Break into work items | `/prd-to-issues` → GitHub issues with boundary maps that feed `/execute`; Ralph can run the AFK loop over unblocked issues |


### PR DESCRIPTION
## Summary

`/research` regularly produces `Uncertain` assumptions whose verdicts are knowable only by running a few lines of code — does the library actually expose this, does the streaming path emit partial tags, does this format render where we need it. Skill Kit had no named exit for that case: `/prototype` (LOGIC, UI) was for design exploration, and `/research` had no way to point at "here is how you discharge this assumption before `/write-a-prd`." The next agent improvised or proceeded with the assumption still flagged.

This PR forks Matt Pocock's `/prototype` into the kit (so other kit skills can rely on its branch structure as a stable contract) and adds a third branch, `FEASIBILITY`, that codifies Kent Beck's *spike solution* as the canonical activity. `/research` Phase 4 and Phase 6 now name `/prototype` FEASIBILITY as the discharge route for cheaply-verifiable `Uncertain` assumptions, and `/execute` Step 0 carries an advisory hook (per XP's *slack* — not blocking) that surfaces un-discharged assumptions before main implementation. The cost framing is XP's *Defect Cost Increase*: a spike at `/research` time costs minutes; the same assumption discovered mid-`/execute` costs hours of pivot.

LOGIC.md and UI.md are verbatim from upstream. SKILL.md is forked with the description tightened to a triple-trigger (LOGIC / UI / FEASIBILITY) and a third bullet added to *Pick a branch*. FEASIBILITY.md is new: two artifact shapes (one focused automated test, or a temporary scratch route when visual confirmation is required), a capture-and-delete protocol grounded in *Once and Only Once*, and a `## What this branch is not for` section that uses spike's one-question-then-dies narrowness to defend cohesion against junk-drawer creep. The skill catalog adds `/prototype` to the side-route roster in `SYSTEM-OVERVIEW.md` and bumps the README skill count from 23 to 24; bundled `SYSTEM-OVERVIEW.md` copies under `help`, `correct-course`, `improve-pipeline`, and `setup-ralph-loop` were synced via `scripts/sync-skill-references.sh`.

## PRD

Closes #74

## Slices

Single-PR scope per the issue's Mediator Verdict — eight file changes implemented as two commits (fork + branch addition, then caller wiring + catalog).

## Key Decisions

- **Fork rather than extend upstream.** The kit needs to evolve `/prototype` independently and have other kit skills reference its branch structure as a stable contract; that requires kit ownership.
- **One slash command, three branches** (not a separate `/spike` skill). Norman's signifier argument: the next agent reaching for "throwaway code that answers a question" should find one home, not two.
- **Advisory not blocking in `/execute` Step 0.** Per XP's *slack*; the user may have a reason to proceed and discover the answer mid-implementation, and the gate's job is to surface, not gate.
- **Verdict folds into the calling artifact, not a sidecar.** *Once and Only Once*: a FEASIBILITY verdict updates the assumption tag in the research artifact rather than creating a parallel record that would rot. Spike issues (`research.storage = spike-issue`) remain immutable point-in-time snapshots; the verdict moves the PRD or supersedes the spike, not the spike's body.