### PR TITLE
Cite Extreme Programming Explained in /research, /execute, /tdd sources

### DIFF
--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -4,6 +4,7 @@ description: "Primary pipeline execution step after /prd-to-issues or for clearl
 sources:
   secondary:
     - "The Checklist Manifesto — Atul Gawande"
+    - "Extreme Programming Explained — Kent Beck"
 ---
 
 # Execute

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -6,6 +6,7 @@ sources:
     - "Software Estimation — Steve McConnell"
   secondary:
     - "The Checklist Manifesto — Atul Gawande"
+    - "Extreme Programming Explained — Kent Beck"
 ---
 
 # Research

--- a/tdd/SKILL.md
+++ b/tdd/SKILL.md
@@ -8,6 +8,7 @@ sources:
     - "Unit Testing — Vladimir Khorikov"
     - "A Philosophy of Software Design — John Ousterhout"
     - "Refactoring — Martin Fowler"
+    - "Extreme Programming Explained — Kent Beck"
 ---
 
 # Test-Driven Development


### PR DESCRIPTION
## Summary

- Closes #76
- Adds `Extreme Programming Explained — Kent Beck` to `sources.secondary` in `research/SKILL.md`, `execute/SKILL.md`, and `tdd/SKILL.md`
- Three-line change; each addition is anchored to existing inline XP attribution in the skill body

## Why

Per `docs/skill-anatomy.md`: *"Only claim a source the body clearly operationalizes."* The inverse holds — when the body operationalizes a source by name, list it. These three skills already named XP concepts inline (DCI, slack, test-first self-similarity) but did not list the framework source, leaving the lineage opaque.

The audit in #76 deliberately rejected pipeline-wide XP integration ("adopt one at a time, where it hurts most" — Beck). Two surfaced candidate gaps (Defect-Response Protocol in `/qa`, Quality-is-not-a-control-variable in `/pre-merge`) are deferred to per-incident extraction in the spirit of #69 and #67.

## Test plan

- [ ] `git diff` shows exactly three lines added — one secondary source per skill
- [ ] `Extreme Programming Explained` appears in each `sources.secondary` list, alphabetical/topical placement preserved
- [ ] No body text changed