### PR TITLE
add(pipeline): Mermaid checklist gates in five GitHub-bound skills (#83)

### DIFF
--- a/compound/SKILL.md
+++ b/compound/SKILL.md
@@ -179,6 +179,8 @@ volatility: evergreen | stable | volatile
 - **Inverts or does not apply when:** [The shapes where following this recommendation would produce the opposite of the intended outcome, or simply not help — e.g., "for N+1-step loops where the tool is non-terminal, the `stopWhen` list must exclude it; see `<sibling-doc>`"]
 - **Sibling docs:** [Links to `docs/solutions/` entries covering adjacent or inverted shapes, if any exist]
 
+[Diagram suggestion: if Rule Scope describes conditional applicability with ≥3 distinguishable branches (multiple Applies-when shapes, or several Inverts-or-does-not-apply shapes that diverge in different directions), consider invoking `/mermaid` for a decision diagram showing which conditions route to which recommendation. Skip when the rule is binary (one Applies-when, one Inverts-when) — prose is already the cleanest rendering at that size.]
+
 ## Solution
 
 [The actual fix. Include before/after code when it helps.]

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -122,6 +122,8 @@ If a gap is found, don't just document it in this slice's `Consumes`. File a pos
 
 Do not force detailed schedule estimates into each issue. The goal is to surface slices that are still too ambiguous for credible commitment.
 
+**Dependency-graph diagram (optional).** Before finalizing the boundary map, if it has ≥2 Produces/Consumes entries across the decomposition, consider invoking `/mermaid` to render the cross-slice dependency graph as a flowchart and embed it alongside the existing lists. The lists stay authoritative — the diagram is a reading aid for reviewers and resumed-session agents who otherwise have to mentally compile the bullet structure back into a graph. Skip the diagram when the boundary map is thin enough that the lists are already the cleanest rendering.
+
 ### 5. Derive the Coverage Matrix
 
 **Skip this step when the PRD decomposes into a single slice.** For single-slice PRDs the boundary map + user-stories-covered field already serve as coverage; a matrix would be pure ceremony.

--- a/research/SKILL.md
+++ b/research/SKILL.md
@@ -488,6 +488,8 @@ For each callback the feature implements:
 
 - `path/to/file.ts` — [What it does and how it's relevant]
 
+[Diagram suggestion: if research surfaces a multi-module architecture (≥3 modules with non-trivial connections, or a layering or boundary the recommended approach must respect), consider invoking `/mermaid` to sketch it — a flowchart or C4 diagram — and embed the source in this section alongside the list. The archive entry is consumed by `/execute` and Ralph AFK loops resuming cold, where a visual reduces the reconstruction cost; the list stays authoritative for grepping by file path. Skip when the architecture is a single module or a flat 2-module hop.]
+
 ## 🔗 Sources
 
 [Every API reference above must trace to one of these. Grouped by confidence.]

--- a/triage-issue/SKILL.md
+++ b/triage-issue/SKILL.md
@@ -90,6 +90,8 @@ Rank by strength of evidence — recent changes to the suspect path, structural 
 
 If the structural diagnosis reveals a deeper architectural problem, note it in the issue for follow-up via `/improve-codebase-architecture`.
 
+**Feedback-loop diagram (optional).** If a system archetype applies (shifting the burden, drift to low performance, fixes that fail, or any other named archetype from the catalog), consider invoking `/mermaid` to render the causal-loop diagram and embed it in the issue. Meadows' archetypes are canonically drawn in the source material; rendering them as prose loses part of what makes the archetype transferable to a reader pattern-matching their own failure. Skip when the archetype is named but its loop is one short causal step that prose already captures cleanly.
+
 ### 3. Identify the fix approach
 
 Run the proposed fix against the Step 2 feedback loop and confirm the loop now passes. If the loop still fails, your root cause identification is wrong — return to Step 2 and revise the hypothesis ranking. Only in the explicit "reproduction was genuinely impossible" branch from Step 2 may you skip this verification; in that case, restate that the root cause is a best-effort analysis based on code reading.

--- a/write-a-prd/SKILL.md
+++ b/write-a-prd/SKILL.md
@@ -248,6 +248,8 @@ Explicit exclusions. Silence means "in scope," so anything the builder might rea
 - **[Place Name]**: [affordance 1], [affordance 2] -> connects to [Other Place]
 - **[Other Place]**: [affordance 3] -> connects to ...
 
+[Diagram suggestion: if this Flow Sketch describes ≥3 steps or any branching UI, consider invoking `/mermaid` to render the flow as a flowchart and embed it alongside the bullet list. The list stays authoritative; the diagram is a reading aid for downstream `/prd-to-issues` decomposition and `/execute` sessions resuming cold. Skip when the flow is short and linear enough that the bullets are already the cleanest rendering.]
+
 ## User Stories
 
 ### Must-haves


### PR DESCRIPTION
## Summary

Issue [#83](https://github.com/chrislacey89/skills/issues/83) proposed adding a checklist gate to five pipeline skills that produce GitHub-bound markdown with structural content — `prd-to-issues`, `write-a-prd`, `triage-issue`, `compound`, and `research`. The motivation is ergonomic, not corrective: bullet lists that *encode* a graph, flow, or feedback loop cost reviewers (and resumed-session agents) more cognitive effort than the diagram itself would. The intervention is intentionally narrow — each skill gains one short note, scoped to one sub-section, with a stated trigger condition that keeps the suggestion silent when the underlying content is thin.

Each note is a *suggestion*, never a hard gate. The bullet lists stay authoritative — the diagram is a reading aid that lives alongside them, not a replacement. The mechanism mirrors the issue's recommended-changes table 1:1: ≥2 Produces/Consumes entries for the boundary-map gate, ≥3 steps or branching UI for the Flow Sketch gate, "if a system archetype applies" for triage, ≥3 conditional branches for compound's Rule Scope, and ≥3 modules with non-trivial connections for the research archive's module sketch. Each note also names a skip condition so reviewers don't read the prompt as default-on — that's the policy-resistance mitigation the Skeptic case in #83 asked for.

Why it matters: reviewers and Ralph AFK loops resume cold from GitHub artifacts. A `/mermaid` source block embedded next to a thick boundary map (or a multi-step flow, or an archetype diagnosis) renders natively in GitHub, VS Code, and Notion, and saves the reader from mentally compiling the bullet structure back into a graph. Pushed indiscriminately, diagrams become the kind of low-signal ceremony reviewers learn to skim — which is why the triggers are quantitative ("≥3 steps", "≥3 branches") and the skip conditions are explicit.

The `/mermaid` skill itself landed earlier via [#84](https://github.com/chrislacey89/skills/pull/84), so all five `/mermaid` references in this PR resolve at install time.

## PRD

Closes #83

## Slices

This is a single-PR change — issue #83's Mediator Verdict scoped it as five `SKILL.md` files each gaining one checklist item, delivered together so reviewers can evaluate the integration end-to-end. No child slices were created.

## Key Decisions

- **Placement is collocated with the artifact section, not centralized.** Norman's *knowledge in the world* principle: the prompt lives where the work happens. No central `docs/diagram-anatomy.md` — premature centralization is the symmetric failure mode (#83 Non-Goals).
- **Each note names a skip condition** alongside the trigger ("Skip when…"). This is the policy-resistance mitigation: a checklist that fires on every run produces filler. The skip lines train the agent to recognize when prose is already the cleanest rendering.
- **`research`'s gate lives in "Relevant Existing Code"** rather than spawning a new "Architecture Sketch" section. Issue #83 explicitly said "Each addition is one short paragraph or list item, not a new section. Existing template structure is preserved."
- **`triage-issue`'s gate lives at the end of Step 2's diagnostic playbook**, where the archetype match is recorded — not in Step 3 (fix approach) or in the template, because the archetype is named in Step 2 and its loop is what the diagram renders.
- **Not added: the Tufte library-gap follow-up** mentioned in #83's "Suggested Further Reading" section. That belongs as a separate `library-gap`-labeled action item, not in the recommended-changes table that this PR implements.