### PR TITLE
update(improve-pipeline, test-verify-install): derive count from manifest + pre-table file-read note

### DIFF
--- a/improve-pipeline/SKILL.md
+++ b/improve-pipeline/SKILL.md
@@ -254,6 +254,8 @@ Example:
 
 The `## Field Incident` and `## Why This Is a Pipeline Problem` sections carry the plain-language walkthrough for this artifact — a reader picking up the issue six months from now should be able to follow what happened and why it matters without opening the downstream repo. Meet the shape and revision bar in `references/writing-for-humans.md` (bundled alongside this skill): domain setup in the user's own words, a front-loaded lede, each recommended change motivated, and a `**Why it matters:**` signpost. The analytical sections (`## Advocate Case`, `## Skeptic Case`, `## Mediator Verdict`) sit beside the walkthrough and stay as tight bullets or short paragraphs — they are not another walkthrough.
 
+**Before writing the Recommended Changes table.** For each row with a target file, open the file and confirm the proposed structure exists — a row that says "add a Quick Reference table entry" is only valid if the target file has a Quick Reference table. Substance and placement are decided in the same read, not in two passes. For proposals that add a new skill bundling a `docs/`-rooted reference, the table must include a `scripts/skill-references.manifest` row alongside the SKILL.md and discovery-doc rows; the bundled-references invariant in `CLAUDE.md` § Shared reference files requires it, and `scripts/sync-skill-references.sh --check` will fail at commit time otherwise.
+
 Use this issue body template:
 
 ```markdown

--- a/scripts/test-verify-install.sh
+++ b/scripts/test-verify-install.sh
@@ -14,6 +14,11 @@ script="$repo_root/scripts/verify-install.sh"
 sandbox="$(mktemp -d)"
 trap 'rm -rf "$sandbox"' EXIT
 
+# Derived from the manifest so the test never needs a hand-edit when entries
+# are added or removed. Mirrors the comment-and-blank filtering used by
+# populate_install_dir below.
+expected_count=$(awk 'NF && !/^[[:space:]]*#/' "$repo_root/scripts/skill-references.manifest" | wc -l | tr -d ' ')
+
 pass=0
 fail=0
 
@@ -67,7 +72,7 @@ output="$(bash "$script" "$install_dir" 2>&1)"
 rc=$?
 set -e
 assert_exit 0 "$rc" "exit 0 when all files present"
-assert_contains "$output" "12 reference(s) present" "reports count"
+assert_contains "$output" "$expected_count reference(s) present" "reports count"
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Same root pattern fired three times in PR #87 (the `/handoff` skill addition): the Recommended Changes table proposed by `/improve-pipeline` issue #86 named five files; the implementation needed seven; one of the omissions broke CI on push. The three instances were a Quick Reference row proposed for a file with no such table, a missing `scripts/skill-references.manifest` entry, and a stale hardcoded count in `scripts/test-verify-install.sh` that drifted from 11 → 12 the moment the manifest grew.

Two changes calibrated to the evidence:

- **`scripts/test-verify-install.sh:18`** — replace the hardcoded `assert_contains "$output" "12 reference(s) present"` with a manifest-derived `$expected_count`, computed once near the top with the same comment-and-blank awk filter `populate_install_dir` already uses. Pure subtraction of brittleness — knowledge-in-the-head (remember to bump the count) becomes knowledge-in-the-world (the count derives itself). One whole class of CI failure goes away forever.
- **`improve-pipeline/SKILL.md` Phase 5** — one short paragraph before the issue body template. Tells the proposal author to open each target file before writing the Recommended Changes table (so substance and placement get decided in one read, not two passes), and that new-skill proposals bundling a `docs/`-rooted reference must include a `scripts/skill-references.manifest` row alongside the SKILL.md and discovery-doc rows.

The two changes split the failure mode by tractability: the test-count miss is fully addressable structurally and gets the pure-subtraction treatment; the placement and missing-manifest-row misses are residual-judgment-shaped and get the minimum possible pointed instruction. Crucially, **no new "new-skill checklist" doc** — the Skeptic case in #88 named Meadows policy resistance as the strongest reason not to add one. Combined diff is 8 lines added, 1 removed.

**Why it matters:** Pipeline proposals' Recommended Changes table is a contract between the proposer and the implementer. Under-specifying it pushes work onto the implementer and erodes trust in the contract. The structural fix eliminates one class of under-specification entirely; the SKILL.md note targets the residual without adding ceremony. Falsification condition stated in #88: if after 5–10 future proposals the manifest-row miss recurs, the SKILL.md note is failing as a forcing function and the fix needs to escalate to auto-detection from SKILL.md content.

## PRD

Closes #88

## Slices

Single-commit change; no slice decomposition.

## Key Decisions

- **Manifest-derivation via awk, not via sync-skill-references.sh import.** The two-line awk reuses the filter `populate_install_dir` already encodes (`NF && !/^[[:space:]]*#/`), so the test stays self-contained without taking a dependency on the sync script's internals.
- **One paragraph, not a subsection.** The Skeptic case in #88 flagged the risk of an "open the file before writing the table" note accumulating into a multi-item checklist over time. The change keeps the addition to one paragraph and makes future expansion require a fresh `/improve-pipeline` run with new triggering evidence.
- **No edits to `CLAUDE.md`.** The bundled-references invariant is already documented there. The SKILL.md note links to it rather than duplicating it.
- **No `/pre-merge` dimension change.** Dimension 10 (Surgical Scope) correctly classified the PR #87 under-specifications as Observations because substantive intent matched. Promoting to Concerns would create false positives on legitimate placement judgment.