### PR TITLE
add(mermaid): contrast-safe init directive for GitHub dark-mode rendering

### DIFF
--- a/mermaid/SKILL.md
+++ b/mermaid/SKILL.md
@@ -78,6 +78,7 @@ Generated Mermaid code must:
 3. Use semantic, human-readable node IDs and labels.
 4. Be indented and line-broken for readability.
 5. Use styling only when it materially improves clarity.
+6. For sequence, state, and entity-relationship diagrams destined for a theme-aware viewer (GitHub, Notion, etc.), prepend the contrast-safe `%%{init: ...}%%` directive from [`references/contrast-for-github.md`](references/contrast-for-github.md). Flowcharts and other diagram types do not need this — their default rendering reads correctly in both light and dark mode.
 
 ## Example
 
@@ -134,6 +135,10 @@ echo 'graph TD
 | Markdown links / wikilinks inside a node label | Not interpreted; renders as raw `[[...]]` | Move the link out of the diagram, or use plain text |
 
 **Quoting rule of thumb:** if a node label contains *any* of `()`, `[]`, `<`, `>`, `:`, `=`, `,`, `;`, `&`, or unbalanced quotes, wrap the whole label in double quotes (`["..."]` for rectangles, `{"..."}` for diamonds).
+
+### Contrast fast-check (theme-aware viewers only)
+
+If the diagram type is **sequence**, **state**, or **entity-relationship** and the destination is a theme-aware viewer (GitHub, Notion, etc.), scan the fenced block for the contrast-safe `%%{init: ...}%%` directive described in [`references/contrast-for-github.md`](references/contrast-for-github.md). 5-second visual check — no re-render required. `mmdc`'s default theme matches the agent's local environment, not the reader's, so a clean parse does not imply readable text on a dark-mode page. See the reference for the per-diagram templates and an optional dark-render SVG inspection if you want belt-and-braces.
 
 ## Handoff
 

--- a/mermaid/references/contrast-for-github.md
+++ b/mermaid/references/contrast-for-github.md
@@ -1,0 +1,108 @@
+# Contrast safety for GitHub-bound diagrams
+
+GitHub renders Mermaid natively and picks the theme (light or dark) from the reader's color scheme. A diagram authored without explicit theme variables uses Mermaid's defaults, which paint sequence-message text, state labels, and ER entity rows in pale colors when the dark theme is active. Layered on light pastel `rect rgb(...)` phase bands or default light fills, the resulting text-on-fill contrast is effectively zero. Parse-only verification with `mmdc` does not surface this — `mmdc`'s default theme matches the agent's local environment, not the reader's.
+
+Three diagram types are affected: **sequence**, **state**, and **entity-relationship**. Flowcharts are not affected — their per-node `classDef` rules pin `color:` per node and override the theme. Other types (gantt, pie, mindmap, etc.) have not exhibited this failure mode.
+
+## When to apply
+
+Apply the init directive when **all** of the following are true:
+
+- The diagram type is sequence, state, or ER.
+- The destination is a theme-aware viewer (GitHub, Notion, anything that switches theme based on the reader's color scheme).
+- You are not deliberately producing a dark-only or light-only artifact.
+
+If the diagram only ever appears in a light-mode-only context (a screenshot, a printed PDF, a fixed-theme docs site), the directive is optional.
+
+## Templates
+
+Each template uses Mermaid's `base` theme — the only theme that accepts custom `themeVariables` (see [config-theming.md](config-theming.md)) — and pins text to `#1f2937` (slate-800) on `#f9fafb` (slate-50) backgrounds. These values read cleanly in both GitHub light and GitHub dark.
+
+### Sequence diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor': '#f9fafb',
+  'primaryTextColor': '#1f2937',
+  'primaryBorderColor': '#9ca3af',
+  'lineColor': '#4b5563',
+  'actorBkg': '#f9fafb',
+  'actorTextColor': '#1f2937',
+  'actorLineColor': '#4b5563',
+  'signalColor': '#4b5563',
+  'signalTextColor': '#1f2937',
+  'labelBoxBkgColor': '#f9fafb',
+  'labelBoxBorderColor': '#9ca3af',
+  'labelTextColor': '#1f2937',
+  'loopTextColor': '#1f2937',
+  'noteBkgColor': '#fef3c7',
+  'noteTextColor': '#1f2937',
+  'noteBorderColor': '#9ca3af'
+}}}%%
+sequenceDiagram
+    participant A
+    participant B
+    A->>B: message
+```
+
+The variables that close the dark-mode gap are `signalTextColor` (arrow message labels), `noteTextColor` (Note over … blocks), `labelTextColor` (rect / loop / alt labels), and `actorTextColor` (participant headers). The rest are included so phase-band `rect rgb(...)` overlays still read cleanly.
+
+### State diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor': '#f9fafb',
+  'primaryTextColor': '#1f2937',
+  'primaryBorderColor': '#9ca3af',
+  'lineColor': '#4b5563',
+  'labelColor': '#1f2937',
+  'labelTextColor': '#1f2937',
+  'secondaryColor': '#e5e7eb',
+  'tertiaryColor': '#f3f4f6'
+}}}%%
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Active
+    Active --> [*]
+```
+
+`primaryTextColor` covers state names; `labelTextColor` covers transition labels.
+
+### Entity-relationship diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {
+  'primaryColor': '#f9fafb',
+  'primaryTextColor': '#1f2937',
+  'primaryBorderColor': '#9ca3af',
+  'lineColor': '#4b5563',
+  'attributeBackgroundColorOdd': '#f9fafb',
+  'attributeBackgroundColorEven': '#f3f4f6'
+}}}%%
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+```
+
+`primaryTextColor` covers entity titles and attribute rows. The two attribute-row background colors are pinned so zebra-striping stays readable when GitHub's dark theme would otherwise tint them.
+
+## Verification (belt-and-braces)
+
+The Verification section of [SKILL.md](../SKILL.md#verification) recommends a 5-second visual scan to confirm the init directive is present on sequence/state/ER blocks destined for theme-aware viewers. For higher-stakes diagrams (a PRD that will be reviewed widely, an issue that will be cited downstream), you can render under the dark theme and grep the SVG for the pinned text color:
+
+```bash
+# Render with the dark theme to surface what a dark-mode GitHub reader sees.
+npx --yes -p @mermaid-js/mermaid-cli mmdc \
+  -i diagram.mmd -o /tmp/dark.svg -t dark -b transparent
+
+# Confirm message / note / state labels use the pinned text color, not a pale default.
+grep -oE '(messageText|noteText|stateLabel|label)[^}]*fill:[^;"]+' /tmp/dark.svg
+```
+
+The `fill:` for each matching class should be `#1f2937` (or whatever pinned color you chose). A pale `#fff` / `#e3e3e3` / pinkish lavender means the init directive did not stick — usually a typo in a variable name or the directive landed below the diagram type declaration (the `%%{init}%%` block must be the first line of the fenced block).
+
+## Version-drift note
+
+The themeVariables surface is real but has shifted between Mermaid majors. The list of variables and their effects is documented in [config-theming.md](config-theming.md), which is auto-generated from the upstream Mermaid project — re-read it on major Mermaid version bumps. If a pinned variable is renamed or removed upstream, the diagram silently degrades to the new default, which may or may not preserve contrast. The verification grep above is the cheapest detection: if it stops finding the pinned `fill:`, the template needs a refresh.
+
+The `base` theme remains the only customizable theme as of this writing. If that changes, prefer the explicitly customizable theme over chasing variable renames.


### PR DESCRIPTION
## Summary

Sequence, state, and ER diagrams generated by `/mermaid` without explicit theme variables render with near-zero text contrast when GitHub picks its dark theme. `mmdc`'s default single-theme verification cannot surface this — the agent's local render matches its own light-mode environment, not what a dark-mode reader sees.

This PR closes the gap structurally — knowledge in the world, not knowledge in the agent's head — without imposing dual-theme rendering ceremony on every diagram.

- New reference `mermaid/references/contrast-for-github.md` documents the failure mode, the per-diagram-type `%%{init: ...}%%` template (sequence, state, ER) using Mermaid's `base` theme with pinned `themeVariables`, an optional dark-render SVG inspection recipe, and a version-drift note that links back to the upstream-tracked `config-theming.md`.
- `mermaid/SKILL.md` Output Specification gains a 7th bullet pointing at the new reference for sequence/state/ER diagrams destined for theme-aware viewers (GitHub, Notion). Flowcharts and other types are unchanged.
- `mermaid/SKILL.md` Verification gains one optional `Contrast fast-check` subsection — a 5-second visual scan for the init directive on affected diagram types. No re-render required; no dual-theme mandate on every diagram.

Verified locally: all three template diagrams render cleanly via `mmdc`; rendering the sequence template with `mmdc -t dark -b transparent` and grepping the SVG confirms `messageText`, `noteText`, `labelText`, and `actor>tspan` all carry the pinned `fill:#1f2937` — the reference's belt-and-braces grep works as documented.

Follows the Mediator Verdict in #94: land item #1 (pre-seed template) and item #3 (reference file); demote item #2 (no dual-render mandate) to a single optional fast-check. The five consumer skills (`/prd-to-issues`, `/write-a-prd`, `/triage-issue`, `/compound`, `/research`) are not touched — they inherit the fix via `/mermaid`.

## PRD

Closes #94