### PR TITLE
add(prd-to-issues): shape-sufficiency check and Consumes-side symmetry (#55, #91)

### DIFF
--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -115,6 +115,7 @@ For each Consumes entry:
 1. If it names a file path — check the file exists.
 2. If it names a function, type, or exported symbol — grep for the export.
 3. If it names a shape (e.g. "Effect Layer", "Zod schema", "React component", "Context provider") — confirm the *shape* matches, not just the name. A pure helper function does not satisfy a claim of "Effect Layer." A plain object does not satisfy a claim of "Zod schema."
+4. If the Consumes entry names a typed symbol from a sibling slice (per `/prd-to-issues` Boundary Map guidance), confirm the consumer code derives its input type from the producer via `import type` (or the language's equivalent) rather than re-declaring the shape. A local re-declaration that happens to match the producer is a DRY violation that will silently drift when the producer evolves; the typed import is the structural fix that makes that drift class impossible.
 
 If any Consumes symbol is missing or wrong-shaped, **stop**. The upstream boundary map is stale. Choose one of:
 

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -66,6 +66,8 @@ For each slice, specify:
 
 **Contract-shape rendering.** When the parent PRD locks a schema, type alias, function signature, or structured input/output shape in code form (per `/write-a-prd`'s Implementation Decisions guidance), the slice's `Produces` field should reference it by location rather than re-render it. Re-render only when the slice introduces a contract shape the PRD did not lock. This keeps the PRD as the single source of truth for locked contracts and avoids drift between two surface forms of the same artifact.
 
+**On the Consumes side**, the same principle applies in mirror: when a slice consumes a contract shape produced by a sibling slice in a typed language (TypeScript, Rust, Python-with-stubs), the slice's `Consumes` field should **name the symbol and its location** — e.g. "From #N: `RunEvalResult` exported by `src/evals/run-experiment.ts`" — rather than re-render the shape in prose. The implementing agent then derives the consumer-side type via `import type` (or the equivalent), and the type system enforces N=1 between producer and consumer at compile time. The carve-out is cross-language Consumes — when the consumer cannot import the producer's type (e.g. a workflow YAML consuming a TS-defined constant), name the shared identifier and treat the prose as the contract; downstream review (`/pre-merge` Dimension 1) is the safety net there.
+
 Example — when the PRD's Implementation Decisions block locks a Drizzle schema:
 
 ```ts

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -124,6 +124,12 @@ If a gap is found, don't just document it in this slice's `Consumes`. File a pos
 
 Do not force detailed schedule estimates into each issue. The goal is to surface slices that are still too ambiguous for credible commitment.
 
+**Shape-sufficiency check.** For each new contract this slice introduces in `Produces` (Zod schema, exported type or interface, function signature, storage method parameter shape, server-function return type), confirm the *shape* is rendered as code in the issue body, not just the *name* listed. If only the name appears, render the shape inline before finalizing the boundary map.
+
+The audit is binary: shape present or absent. Shape correctness is evaluated at the §6 Quiz step; shape presence is the prerequisite that lets the Quiz step do its job.
+
+This check exists because PRDs frequently sketch contract shapes in prose without locking them in code form (e.g., "exports a Zod schema with category_scores keyed by …"). The Contract-shape rendering subsection above covers two cases — PRD locked in code (reference by location) and slice introduces a contract the PRD did not lock (re-render). The third case — PRD sketched in prose without locking in code — is where this check fires when the rule's "did not lock" wording is read narrowly. The slice issue is the durable contract `/execute` and `/pre-merge` inherit; the shape lives in code form in the slice's `Produces` regardless of the PRD's surface form for it.
+
 **Dependency-graph diagram (optional).** Before finalizing the boundary map, if it has ≥2 Produces/Consumes entries across the decomposition, consider invoking `/mermaid` to render the cross-slice dependency graph as a flowchart and embed it alongside the existing lists. The lists stay authoritative — the diagram is a reading aid for reviewers and resumed-session agents who otherwise have to mentally compile the bullet structure back into a graph. Skip the diagram when the boundary map is thin enough that the lists are already the cleanest rendering.
 
 ### 5. Derive the Coverage Matrix


### PR DESCRIPTION
## Summary

Two narrowly-scoped boundary-map upgrades to `/prd-to-issues`, both grounded in field incidents:

- **#91** — Symmetrize the existing §4 Contract-shape rendering rule onto the Consumes side: typed-language sibling slices should name the producer's exported symbol and location rather than re-render the shape in prose, so the consumer derives the type via `import type` and the type system enforces N=1 producer/consumer parity. Cross-language Consumes is explicitly carved out. `/execute`'s Consumes verification gate gets a parallel advisory bullet.
- **#55** — Add a fifth §4 audit (Shape-sufficiency check) alongside the existing four (Orthogonality, Scope completeness, Consumes plausibility, Estimate-readiness). Binary by design: shape present or absent in each slice's `Produces`. Shape correctness stays the §6 Quiz step's responsibility. Closes the ambiguity in the existing Contract-shape rendering rule's "did not lock" wording for PRDs that sketch contracts in prose.

## Issues

Closes #55
Closes #91

## Key Decisions

- Issue #55's Mediator surfaced a narrower-alternative (sharpen the "did not lock" wording instead of adding a check). Implemented the verdict-as-filed (structural check) on Gawande's ineptitude grounds — rule clarity does not address reliable application; only structural enforcement does. Re-evaluable if three or more decompositions under the new check end up with `Produces` blocks past 80 lines.
- Issue #91's Mediator gated the change to a single-paragraph extension, not a new mechanism. Kept the change to one paragraph in `/prd-to-issues` plus one advisory bullet in `/execute`. No new section, no new verification gate.
- The Shape-sufficiency check is placed *before* the optional Dependency-graph diagram so it sits alongside the other four §4 audits, not stranded after them.