### PR TITLE
add(execute): read issue comment thread in Step 1 — close read side of continuation loop (#105)

### DIFF
--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -134,7 +134,7 @@ Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot
 
 ### Step 5: /execute (HITL or AFK via Ralph)
 
-**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues.
+**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues — including their comment threads, where the previous iteration forwarded exact errors and partial-progress notes (the read side of the error-forwarding loop documented below).
 
 **Default progression:** Start with HITL Ralph, not AFK Ralph. Use HITL to refine the execution prompt, confirm the repo's quality bar is actually encoded in the workflow, and prove that slice boundaries and feedback loops are working. Go AFK only once the runner is reliably choosing the right next slice and producing reviewable commits without needing frequent rescue.
 

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -134,7 +134,7 @@ Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot
 
 ### Step 5: /execute (HITL or AFK via Ralph)
 
-**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues.
+**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues — including their comment threads, where the previous iteration forwarded exact errors and partial-progress notes (the read side of the error-forwarding loop documented below).
 
 **Default progression:** Start with HITL Ralph, not AFK Ralph. Use HITL to refine the execution prompt, confirm the repo's quality bar is actually encoded in the workflow, and prove that slice boundaries and feedback loops are working. Go AFK only once the runner is reliably choosing the right next slice and producing reviewable commits without needing frequent rescue.
 

--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -133,6 +133,12 @@ This gate is scoped to intra-repo symbols (paths, exports, shapes). The mirror c
 
 Read any referenced plan, PRD, or GitHub issue. Explore the codebase to understand the relevant files, patterns, and conventions. If the task is ambiguous, ask the user to clarify scope before proceeding.
 
+**Read the issue comment thread (issue-based work only).** When the task is a GitHub issue, read its comment thread before implementing — do not stop at the body. Step 0's issue-shape detection gate already ran `gh issue view <n> --comments`, so the thread is in context; reuse it rather than re-fetching. The comments are where the pipeline's continuation state lives: prior-iteration handoff notes (what was done, what remains, the exact error output a previous context window hit), plateau-stop notes naming what did *not* advance, post-hoc correction comments filed against this issue when an upstream boundary map drifted, and explicit human scope changes added after the issue was authored. In AFK Ralph loops this is load-bearing — iteration N+1 is designed to continue from what iteration N wrote into the thread, so skipping it re-derives or repeats work the previous iteration already explained.
+
+**Precedence rule.** The issue body remains the durable contract. Comments augment it; they do not silently override it. A comment is an authoritative addition only when it is (a) a pipeline-authored continuation or correction comment, or (b) an explicit human scope change. Freeform discussion is context, never an override. If a comment appears to contradict the body on scope, and it is not a clear pipeline-authored correction or human scope change, flag the conflict to the user rather than acting on the comment.
+
+Skip this read for one-off tasks not tied to a GitHub issue (the same scope guard Step 0 uses).
+
 **Read the research artifact for this feature.** The PRD's "Research Reference" section names where it lives — one of two locations depending on the project's `research.storage` mode:
 
 1. **Spike-issue mode** — the PRD references a closed `research`-labeled GitHub issue (`Refs #<spike-issue-number>`). Read it with:

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -134,7 +134,7 @@ Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot
 
 ### Step 5: /execute (HITL or AFK via Ralph)
 
-**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues.
+**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues — including their comment threads, where the previous iteration forwarded exact errors and partial-progress notes (the read side of the error-forwarding loop documented below).
 
 **Default progression:** Start with HITL Ralph, not AFK Ralph. Use HITL to refine the execution prompt, confirm the repo's quality bar is actually encoded in the workflow, and prove that slice boundaries and feedback loops are working. Go AFK only once the runner is reliably choosing the right next slice and producing reviewable commits without needing frequent rescue.
 

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -134,7 +134,7 @@ Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot
 
 ### Step 5: /execute (HITL or AFK via Ralph)
 
-**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues.
+**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues — including their comment threads, where the previous iteration forwarded exact errors and partial-progress notes (the read side of the error-forwarding loop documented below).
 
 **Default progression:** Start with HITL Ralph, not AFK Ralph. Use HITL to refine the execution prompt, confirm the repo's quality bar is actually encoded in the workflow, and prove that slice boundaries and feedback loops are working. Go AFK only once the runner is reliably choosing the right next slice and producing reviewable commits without needing frequent rescue.
 

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -134,7 +134,7 @@ Frontmatter captures `date`, `repo`, `feature`, and `installed_versions_snapshot
 
 ### Step 5: /execute (HITL or AFK via Ralph)
 
-**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues.
+**What it does:** Executes the next concrete slice. In HITL mode, you run `/execute` directly on a specific issue. In AFK mode, Ralph acts as the runner/persona that repeatedly picks the next unblocked issue, invokes `/execute` + `/tdd`, commits, and iterates. Each AFK iteration is a fresh context window that reads the last commits and open issues — including their comment threads, where the previous iteration forwarded exact errors and partial-progress notes (the read side of the error-forwarding loop documented below).
 
 **Default progression:** Start with HITL Ralph, not AFK Ralph. Use HITL to refine the execution prompt, confirm the repo's quality bar is actually encoded in the workflow, and prove that slice boundaries and feedback loops are working. Go AFK only once the runner is reliably choosing the right next slice and producing reviewable commits without needing frequent rescue.
 


### PR DESCRIPTION
## Summary

The pipeline writes durable continuation state into GitHub issue comments from at least four sites — `/execute` Step 6 handoff notes (what was done, what remains, the exact error output a context window hit), the plateau-stop rule, post-hoc upstream-correction comments, and `/setup-ralph-loop`'s "comments carry exact errors" contract. But until now only `/pre-merge` read that channel back; `/execute` Step 1 — the step whose whole job is to load context before any code is written — read the issue body, the research artifact, and `docs/solutions/`, and never the comment thread. Step 0 fetched `--comments` but used it for a single regex (`Decomposed into:`). The result was an unclosed feedback loop: in AFK Ralph runs, iteration N+1 is *designed* to continue from what N wrote into the thread, but the start of N+1 was never told to read it, so it re-derived or repeated work the previous iteration already explained.

This closes the read side. `/execute` Step 1 now reads the issue comment thread for issue-based work — reusing the comments Step 0 already fetched, so there is no second `gh` call — covering prior-iteration handoffs, plateau notes, post-hoc corrections, and explicit human scope changes. A precedence rule keeps the issue body canonical: comments augment, they never silently override; only pipeline-authored continuation/correction comments and explicit human scope changes are authoritative additions, freeform discussion is context, and any apparent body-vs-comment conflict is flagged to the user rather than acted on. The read is scoped to issue-based work with the same one-off-task guard Step 0 uses. `SYSTEM-OVERVIEW.md` line 137 (the AFK read side) now names comment threads, matching the write side at line 153 and the durable substrate at line 413 — making the canonical state model internally consistent.

The change follows the issue's Mediator verdict ("proceed narrowly"): reuse the existing fetch rather than add ceremony (Norman featuritis), make the precedence rule mandatory not optional (protect the "body is the contract" invariant), and scope to issue work. Meadows Leverage Point 6: the continuation information already exists in the thread; the fix restores the missing information flow to the point where the next decision is made.

## PRD

Closes #105

## Key Decisions

- The issue named `references/SYSTEM-OVERVIEW.md` as the edit target, but that path is a bundled copy. The canonical file is `SYSTEM-OVERVIEW.md` at the repo root; the 4 bundled `references/` copies (correct-course, help, improve-pipeline, setup-ralph-loop) were regenerated via `scripts/sync-skill-references.sh`, not hand-edited. `sync-skill-references.sh --check` passes.
- Respected all four Non-Goals: Step 0's `Decomposed into:` regex untouched, no second `gh` fetch added, the "body is durable contract" invariant preserved via the precedence rule, and `/pre-merge` / `/setup-ralph-loop` / `/prd-to-issues` / `/handoff` left unchanged.
