### PR TITLE
Add /walk-commits — interactive commit-by-commit comprehension walkthrough before merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Use these categories consistently across the repo:
 
 - **Primary pipeline skills** — direct-entry steps in the default delivery path, plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — usually not top-level entry points for a feature, but delegated when a narrower decision is unresolved: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — valid alternate or supporting paths beside the main pipeline: `/qa`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`, `/handoff`
+- **Side-route skills** — valid alternate or supporting paths beside the main pipeline: `/qa`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/walk-commits`, `/help`, `/correct-course`, `/handoff`
 - **Infrastructure skills** — project setup or safety tooling, not normal delivery steps: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 Each skill should make its role obvious.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Skill Kit
 
 [![License: MIT](https://img.shields.io/github/license/chrislacey89/skills)](LICENSE)
-![Skills](https://img.shields.io/badge/skills-26-blue)
+![Skills](https://img.shields.io/badge/skills-27-blue)
 ![CLI](https://img.shields.io/badge/npx%20skills-compatible-green)
 
-Skill Kit is a pipeline-first Claude Code skills pack for structured feature delivery. 26 composable skills that take a feature from idea to shipped — with explicit handoffs, verified research, and a compounding knowledge loop.
+Skill Kit is a pipeline-first Claude Code skills pack for structured feature delivery. 27 composable skills that take a feature from idea to shipped — with explicit handoffs, verified research, and a compounding knowledge loop.
 
 Built around structured research, GitHub-native state, and a compounding knowledge loop in `docs/solutions/`. Compatible with Claude Code, Cursor, Windsurf, and any agent that can consume SKILL.md files.
 
@@ -81,6 +81,7 @@ The pipeline is the default path, not a prison. Skills can backtrack when assump
 |-------|-------------|
 | [qa](qa/) | Single entry point for bug conversations; files lightweight issues and delegates per-issue to `/triage-issue` for deep diagnosis |
 | [pre-merge](pre-merge/) | Author-mode: create the PR and run an architectural review before merge. Reviewer-mode (`--pr <n>`): review someone else's PR and draft comment text |
+| [walk-commits](walk-commits/) | Interactive commit-by-commit comprehension walkthrough before merge — intent, riskiest line, deliberate oddities, what's absent by design, per-commit sign-off (optional, recommended by `/pre-merge`) |
 | [compound](compound/) | Capture lessons learned into docs/solutions/ |
 | [ubiquitous-language](ubiquitous-language/) | DDD glossary with decisions register |
 

--- a/SYSTEM-OVERVIEW.md
+++ b/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`, `/handoff`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/walk-commits`, `/help`, `/correct-course`, `/handoff`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -295,6 +295,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
 | `/ubiquitous-language` | Terminology ambiguity or competing domain terms | `UBIQUITOUS_LANGUAGE.md` with decisions register | Returns to the caller workflow |
 | `/ts-audit` | TypeScript or React files to audit | Structured findings report grouped by category | `/execute` or `/pre-merge` |
+| `/walk-commits` | Finished branch ready to merge, plus the base branch to diff against | Reviewer comprehension and per-commit sign-off (🟢/🟡/🔴) with open items to resolve — a decision, not a durable file | Merge, then `/compound` only when a durable lesson emerged |
 | `/help` | Uncertainty about current pipeline position | Next-step recommendation with a one-line reason | The recommended next skill |
 | `/correct-course` | Invalidated artifact or changed assumption | Blast-radius diagnosis and artifact cleanup plan | The earliest skill that needs to re-run |
 | `/handoff` | Long session with no natural compression artifact — mid-skill, exploratory, side-route, or non-pipeline work | Transient handoff doc at a `mktemp` path; references existing artifacts by path, URL, or issue number | Fresh session opened by the user with the doc as input |
@@ -320,6 +321,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 - `/request-refactor-plan` and `/improve-codebase-architecture` produce refactor work that can re-enter at `/execute`
 - `/improve-pipeline` captures Skill Kit improvement proposals as GitHub issues in `chrislacey89/skills`, then optionally flows into reviewed implementation of the named repo changes
 - `/ts-audit` produces type-safety findings that can feed into `/execute` for fixes or inform `/pre-merge` architectural review
+- `/walk-commits` is an optional commit-by-commit comprehension walkthrough at the `/pre-merge` → merge boundary; `/pre-merge` Phase 4 recommends it (without invoking) when the person merging didn't author the diff, and `/execute` Step 5/6 names it as an option before `/pre-merge`. It produces reviewer comprehension and sign-off, not defect findings, and never auto-runs
 - `/help` reads repo state and recommends the next pipeline skill with a one-line reason — advisory only, never runs the next skill itself
 - `/correct-course` diagnoses stale artifacts when an upstream assumption fails, walks the cleanup, and hands off to the earliest skill that needs to re-run
 - `/handoff` is invoked ad-hoc when no inter-skill compression artifact covers the situation (mid-skill, exploratory, non-pipeline work, or cross-machine/cross-agent handoff); it is not part of any default path and is not a substitute for the `**Next session:**` runtime line primary skills already emit
@@ -381,6 +383,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 ├── ts-audit/                       # Audit TypeScript code against Total TypeScript library references
 │   ├── SKILL.md
 │   └── evals/
+├── walk-commits/SKILL.md           # Interactive commit-by-commit comprehension walkthrough before merge (optional, recommended by /pre-merge)
 ├── help/SKILL.md                   # Read repo state and recommend the next pipeline skill (advisory only)
 └── correct-course/SKILL.md         # Diagnose stale artifacts and walk the cleanup when an upstream assumption fails
 ```
@@ -437,6 +440,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Write tests first | `/tdd` for strict red-green-refactor, usually delegated from `/execute` |
 | Run a QA session or report bugs | `/qa` — single entry point for bug conversations; files lightweight GitHub issues in domain language and delegates per-issue to `/triage-issue` when a specific bug needs root-cause diagnosis |
 | Review and create PR before merge | `/pre-merge` — creates PR with PRD lineage, runs architectural review |
+| Understand a branch commit-by-commit before merging it | `/walk-commits` — interactive per-commit walkthrough (intent, riskiest line, deliberate oddities, what's absent by design) with 🟢/🟡/🔴 sign-off; optional, recommended by `/pre-merge`, distinct from its defect review |
 | Improve Skill Kit itself | `/improve-pipeline` — capture a pipeline-level lesson as a GitHub issue in `chrislacey89/skills` after loading canonical Skill Kit context |
 | Investigate a specific bug deeply | Start with `/qa` — its Step 3.5 depth check delegates to `/triage-issue` for root-cause analysis, structural diagnosis, and a TDD fix plan that flows into `/execute` |
 | Plan a refactor | `/request-refactor-plan` — tiny commits RFC as GitHub issue, then implement via `/execute` |

--- a/correct-course/references/SYSTEM-OVERVIEW.md
+++ b/correct-course/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`, `/handoff`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/walk-commits`, `/help`, `/correct-course`, `/handoff`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -295,6 +295,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
 | `/ubiquitous-language` | Terminology ambiguity or competing domain terms | `UBIQUITOUS_LANGUAGE.md` with decisions register | Returns to the caller workflow |
 | `/ts-audit` | TypeScript or React files to audit | Structured findings report grouped by category | `/execute` or `/pre-merge` |
+| `/walk-commits` | Finished branch ready to merge, plus the base branch to diff against | Reviewer comprehension and per-commit sign-off (🟢/🟡/🔴) with open items to resolve — a decision, not a durable file | Merge, then `/compound` only when a durable lesson emerged |
 | `/help` | Uncertainty about current pipeline position | Next-step recommendation with a one-line reason | The recommended next skill |
 | `/correct-course` | Invalidated artifact or changed assumption | Blast-radius diagnosis and artifact cleanup plan | The earliest skill that needs to re-run |
 | `/handoff` | Long session with no natural compression artifact — mid-skill, exploratory, side-route, or non-pipeline work | Transient handoff doc at a `mktemp` path; references existing artifacts by path, URL, or issue number | Fresh session opened by the user with the doc as input |
@@ -320,6 +321,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 - `/request-refactor-plan` and `/improve-codebase-architecture` produce refactor work that can re-enter at `/execute`
 - `/improve-pipeline` captures Skill Kit improvement proposals as GitHub issues in `chrislacey89/skills`, then optionally flows into reviewed implementation of the named repo changes
 - `/ts-audit` produces type-safety findings that can feed into `/execute` for fixes or inform `/pre-merge` architectural review
+- `/walk-commits` is an optional commit-by-commit comprehension walkthrough at the `/pre-merge` → merge boundary; `/pre-merge` Phase 4 recommends it (without invoking) when the person merging didn't author the diff, and `/execute` Step 5/6 names it as an option before `/pre-merge`. It produces reviewer comprehension and sign-off, not defect findings, and never auto-runs
 - `/help` reads repo state and recommends the next pipeline skill with a one-line reason — advisory only, never runs the next skill itself
 - `/correct-course` diagnoses stale artifacts when an upstream assumption fails, walks the cleanup, and hands off to the earliest skill that needs to re-run
 - `/handoff` is invoked ad-hoc when no inter-skill compression artifact covers the situation (mid-skill, exploratory, non-pipeline work, or cross-machine/cross-agent handoff); it is not part of any default path and is not a substitute for the `**Next session:**` runtime line primary skills already emit
@@ -381,6 +383,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 ├── ts-audit/                       # Audit TypeScript code against Total TypeScript library references
 │   ├── SKILL.md
 │   └── evals/
+├── walk-commits/SKILL.md           # Interactive commit-by-commit comprehension walkthrough before merge (optional, recommended by /pre-merge)
 ├── help/SKILL.md                   # Read repo state and recommend the next pipeline skill (advisory only)
 └── correct-course/SKILL.md         # Diagnose stale artifacts and walk the cleanup when an upstream assumption fails
 ```
@@ -437,6 +440,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Write tests first | `/tdd` for strict red-green-refactor, usually delegated from `/execute` |
 | Run a QA session or report bugs | `/qa` — single entry point for bug conversations; files lightweight GitHub issues in domain language and delegates per-issue to `/triage-issue` when a specific bug needs root-cause diagnosis |
 | Review and create PR before merge | `/pre-merge` — creates PR with PRD lineage, runs architectural review |
+| Understand a branch commit-by-commit before merging it | `/walk-commits` — interactive per-commit walkthrough (intent, riskiest line, deliberate oddities, what's absent by design) with 🟢/🟡/🔴 sign-off; optional, recommended by `/pre-merge`, distinct from its defect review |
 | Improve Skill Kit itself | `/improve-pipeline` — capture a pipeline-level lesson as a GitHub issue in `chrislacey89/skills` after loading canonical Skill Kit context |
 | Investigate a specific bug deeply | Start with `/qa` — its Step 3.5 depth check delegates to `/triage-issue` for root-cause analysis, structural diagnosis, and a TDD fix plan that flows into `/execute` |
 | Plan a refactor | `/request-refactor-plan` — tiny commits RFC as GitHub issue, then implement via `/execute` |

--- a/docs/using-this-pack.md
+++ b/docs/using-this-pack.md
@@ -150,6 +150,7 @@ These support or re-enter the main flow:
 - `/improve-codebase-architecture`
 - `/ubiquitous-language`
 - `/ts-audit`
+- `/walk-commits` — interactive commit-by-commit comprehension walkthrough before merge (optional; recommended by `/pre-merge`, distinct from its defect review)
 - `/help` — orientation skill that reads repo state and recommends the next pipeline skill
 - `/correct-course` — invocable backtracking skill for when an upstream artifact has gone stale
 - `/handoff` — invocable session-compaction skill for when no inter-skill compression artifact fits (mid-skill, exploratory, or cross-agent handoff); writes a transient doc at a `mktemp` path rather than inside the repo

--- a/execute/SKILL.md
+++ b/execute/SKILL.md
@@ -359,6 +359,8 @@ Do not flip a box you did not actually verify, and do not touch lines outside th
 
 Wait for the user to review and confirm. If they flag items that need fixing, address them, commit the fixes, and re-present the checklist. Only proceed to Step 6 after user confirmation.
 
+**Optional comprehension pass before review.** If the person who will merge this branch did not author it, or wants to internalize it commit-by-commit before approving, `/walk-commits` is an option *before* `/pre-merge` — an interactive per-commit walkthrough (intent, riskiest line, deliberate oddities, what's absent by design, per-commit sign-off). It is optional and never auto-invoked; name it as a choice, do not run it automatically.
+
 **How the "Ready for PR Review" item drives the handoff:** If the user confirms this final item, Step 6 runs cleanup and then automatically invokes `/pre-merge` with the PRD issue number (if the task originated from one). If the user confirms the behavior, code quality, and acceptance criteria items but answers "no" to the PR review item — because they want to batch with more work, are waiting on external input, or plan to sit on the branch — Step 6 runs cleanup and `/execute` exits cleanly. The user invokes `/pre-merge` manually when ready.
 
 ### 6. Cleanup and Handoff

--- a/help/references/SYSTEM-OVERVIEW.md
+++ b/help/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`, `/handoff`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/walk-commits`, `/help`, `/correct-course`, `/handoff`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -295,6 +295,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
 | `/ubiquitous-language` | Terminology ambiguity or competing domain terms | `UBIQUITOUS_LANGUAGE.md` with decisions register | Returns to the caller workflow |
 | `/ts-audit` | TypeScript or React files to audit | Structured findings report grouped by category | `/execute` or `/pre-merge` |
+| `/walk-commits` | Finished branch ready to merge, plus the base branch to diff against | Reviewer comprehension and per-commit sign-off (🟢/🟡/🔴) with open items to resolve — a decision, not a durable file | Merge, then `/compound` only when a durable lesson emerged |
 | `/help` | Uncertainty about current pipeline position | Next-step recommendation with a one-line reason | The recommended next skill |
 | `/correct-course` | Invalidated artifact or changed assumption | Blast-radius diagnosis and artifact cleanup plan | The earliest skill that needs to re-run |
 | `/handoff` | Long session with no natural compression artifact — mid-skill, exploratory, side-route, or non-pipeline work | Transient handoff doc at a `mktemp` path; references existing artifacts by path, URL, or issue number | Fresh session opened by the user with the doc as input |
@@ -320,6 +321,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 - `/request-refactor-plan` and `/improve-codebase-architecture` produce refactor work that can re-enter at `/execute`
 - `/improve-pipeline` captures Skill Kit improvement proposals as GitHub issues in `chrislacey89/skills`, then optionally flows into reviewed implementation of the named repo changes
 - `/ts-audit` produces type-safety findings that can feed into `/execute` for fixes or inform `/pre-merge` architectural review
+- `/walk-commits` is an optional commit-by-commit comprehension walkthrough at the `/pre-merge` → merge boundary; `/pre-merge` Phase 4 recommends it (without invoking) when the person merging didn't author the diff, and `/execute` Step 5/6 names it as an option before `/pre-merge`. It produces reviewer comprehension and sign-off, not defect findings, and never auto-runs
 - `/help` reads repo state and recommends the next pipeline skill with a one-line reason — advisory only, never runs the next skill itself
 - `/correct-course` diagnoses stale artifacts when an upstream assumption fails, walks the cleanup, and hands off to the earliest skill that needs to re-run
 - `/handoff` is invoked ad-hoc when no inter-skill compression artifact covers the situation (mid-skill, exploratory, non-pipeline work, or cross-machine/cross-agent handoff); it is not part of any default path and is not a substitute for the `**Next session:**` runtime line primary skills already emit
@@ -381,6 +383,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 ├── ts-audit/                       # Audit TypeScript code against Total TypeScript library references
 │   ├── SKILL.md
 │   └── evals/
+├── walk-commits/SKILL.md           # Interactive commit-by-commit comprehension walkthrough before merge (optional, recommended by /pre-merge)
 ├── help/SKILL.md                   # Read repo state and recommend the next pipeline skill (advisory only)
 └── correct-course/SKILL.md         # Diagnose stale artifacts and walk the cleanup when an upstream assumption fails
 ```
@@ -437,6 +440,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Write tests first | `/tdd` for strict red-green-refactor, usually delegated from `/execute` |
 | Run a QA session or report bugs | `/qa` — single entry point for bug conversations; files lightweight GitHub issues in domain language and delegates per-issue to `/triage-issue` when a specific bug needs root-cause diagnosis |
 | Review and create PR before merge | `/pre-merge` — creates PR with PRD lineage, runs architectural review |
+| Understand a branch commit-by-commit before merging it | `/walk-commits` — interactive per-commit walkthrough (intent, riskiest line, deliberate oddities, what's absent by design) with 🟢/🟡/🔴 sign-off; optional, recommended by `/pre-merge`, distinct from its defect review |
 | Improve Skill Kit itself | `/improve-pipeline` — capture a pipeline-level lesson as a GitHub issue in `chrislacey89/skills` after loading canonical Skill Kit context |
 | Investigate a specific bug deeply | Start with `/qa` — its Step 3.5 depth check delegates to `/triage-issue` for root-cause analysis, structural diagnosis, and a TDD fix plan that flows into `/execute` |
 | Plan a refactor | `/request-refactor-plan` — tiny commits RFC as GitHub issue, then implement via `/execute` |

--- a/help/references/using-this-pack.md
+++ b/help/references/using-this-pack.md
@@ -150,6 +150,7 @@ These support or re-enter the main flow:
 - `/improve-codebase-architecture`
 - `/ubiquitous-language`
 - `/ts-audit`
+- `/walk-commits` — interactive commit-by-commit comprehension walkthrough before merge (optional; recommended by `/pre-merge`, distinct from its defect review)
 - `/help` — orientation skill that reads repo state and recommends the next pipeline skill
 - `/correct-course` — invocable backtracking skill for when an upstream artifact has gone stale
 - `/handoff` — invocable session-compaction skill for when no inter-skill compression artifact fits (mid-skill, exploratory, or cross-agent handoff); writes a transient doc at a `mktemp` path rather than inside the repo

--- a/improve-pipeline/references/SYSTEM-OVERVIEW.md
+++ b/improve-pipeline/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`, `/handoff`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/walk-commits`, `/help`, `/correct-course`, `/handoff`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -295,6 +295,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
 | `/ubiquitous-language` | Terminology ambiguity or competing domain terms | `UBIQUITOUS_LANGUAGE.md` with decisions register | Returns to the caller workflow |
 | `/ts-audit` | TypeScript or React files to audit | Structured findings report grouped by category | `/execute` or `/pre-merge` |
+| `/walk-commits` | Finished branch ready to merge, plus the base branch to diff against | Reviewer comprehension and per-commit sign-off (🟢/🟡/🔴) with open items to resolve — a decision, not a durable file | Merge, then `/compound` only when a durable lesson emerged |
 | `/help` | Uncertainty about current pipeline position | Next-step recommendation with a one-line reason | The recommended next skill |
 | `/correct-course` | Invalidated artifact or changed assumption | Blast-radius diagnosis and artifact cleanup plan | The earliest skill that needs to re-run |
 | `/handoff` | Long session with no natural compression artifact — mid-skill, exploratory, side-route, or non-pipeline work | Transient handoff doc at a `mktemp` path; references existing artifacts by path, URL, or issue number | Fresh session opened by the user with the doc as input |
@@ -320,6 +321,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 - `/request-refactor-plan` and `/improve-codebase-architecture` produce refactor work that can re-enter at `/execute`
 - `/improve-pipeline` captures Skill Kit improvement proposals as GitHub issues in `chrislacey89/skills`, then optionally flows into reviewed implementation of the named repo changes
 - `/ts-audit` produces type-safety findings that can feed into `/execute` for fixes or inform `/pre-merge` architectural review
+- `/walk-commits` is an optional commit-by-commit comprehension walkthrough at the `/pre-merge` → merge boundary; `/pre-merge` Phase 4 recommends it (without invoking) when the person merging didn't author the diff, and `/execute` Step 5/6 names it as an option before `/pre-merge`. It produces reviewer comprehension and sign-off, not defect findings, and never auto-runs
 - `/help` reads repo state and recommends the next pipeline skill with a one-line reason — advisory only, never runs the next skill itself
 - `/correct-course` diagnoses stale artifacts when an upstream assumption fails, walks the cleanup, and hands off to the earliest skill that needs to re-run
 - `/handoff` is invoked ad-hoc when no inter-skill compression artifact covers the situation (mid-skill, exploratory, non-pipeline work, or cross-machine/cross-agent handoff); it is not part of any default path and is not a substitute for the `**Next session:**` runtime line primary skills already emit
@@ -381,6 +383,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 ├── ts-audit/                       # Audit TypeScript code against Total TypeScript library references
 │   ├── SKILL.md
 │   └── evals/
+├── walk-commits/SKILL.md           # Interactive commit-by-commit comprehension walkthrough before merge (optional, recommended by /pre-merge)
 ├── help/SKILL.md                   # Read repo state and recommend the next pipeline skill (advisory only)
 └── correct-course/SKILL.md         # Diagnose stale artifacts and walk the cleanup when an upstream assumption fails
 ```
@@ -437,6 +440,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Write tests first | `/tdd` for strict red-green-refactor, usually delegated from `/execute` |
 | Run a QA session or report bugs | `/qa` — single entry point for bug conversations; files lightweight GitHub issues in domain language and delegates per-issue to `/triage-issue` when a specific bug needs root-cause diagnosis |
 | Review and create PR before merge | `/pre-merge` — creates PR with PRD lineage, runs architectural review |
+| Understand a branch commit-by-commit before merging it | `/walk-commits` — interactive per-commit walkthrough (intent, riskiest line, deliberate oddities, what's absent by design) with 🟢/🟡/🔴 sign-off; optional, recommended by `/pre-merge`, distinct from its defect review |
 | Improve Skill Kit itself | `/improve-pipeline` — capture a pipeline-level lesson as a GitHub issue in `chrislacey89/skills` after loading canonical Skill Kit context |
 | Investigate a specific bug deeply | Start with `/qa` — its Step 3.5 depth check delegates to `/triage-issue` for root-cause analysis, structural diagnosis, and a TDD fix plan that flows into `/execute` |
 | Plan a refactor | `/request-refactor-plan` — tiny commits RFC as GitHub issue, then implement via `/execute` |

--- a/pre-merge/SKILL.md
+++ b/pre-merge/SKILL.md
@@ -197,6 +197,8 @@ If a concern warrants deeper work, note: "Consider running `/request-refactor-pl
 
 If a finding looks like a behavioral bug, note: "Consider running `/qa` to verify." Do not file an issue.
 
+If the person about to merge did not author the diff — or hasn't internalized it commit-by-commit — note: "Consider running `/walk-commits` for an interactive per-commit comprehension walkthrough before merge." Do not invoke it. This is a comprehension/sign-off pass, distinct from the defect review above; it does not replace these findings.
+
 Omit any tier that has zero findings.
 
 **At the very end of Phase 4 output, print the runtime handoff line if — and only if — a durable lesson emerged from this work that future `/research` or `/write-a-prd` would benefit from:**

--- a/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
+++ b/setup-ralph-loop/references/SYSTEM-OVERVIEW.md
@@ -267,7 +267,7 @@ Use this taxonomy consistently:
 
 - **Primary pipeline skills** — the default feature-delivery path plus the milestone-planning branch for oversized work: `/shape`, `/create-milestone`, `/research`, `/write-a-prd`, `/prd-to-issues`, `/execute`, `/pre-merge`, `/compound`
 - **Invoked helper skills** — delegated from another skill when a narrower question needs focused rigor: `/api-design-review`, `/design-an-interface`, `/tdd`, `/triage-issue`
-- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/help`, `/correct-course`, `/handoff`
+- **Side-route skills** — alternate entry points or supporting paths that reconnect to the main workflow: `/qa`, `/prototype`, `/request-refactor-plan`, `/improve-codebase-architecture`, `/improve-pipeline`, `/ubiquitous-language`, `/ts-audit`, `/walk-commits`, `/help`, `/correct-course`, `/handoff`
 - **Infrastructure skills** — repo setup and safety tooling, not feature-delivery stages: `/init-pipeline`, `/setup-pre-commit`, `/setup-ralph-loop`, `/git-guardrails-claude-code`
 
 ### Handoff Table
@@ -295,6 +295,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 | `/improve-pipeline` | Pipeline-level lesson from real-world usage of Skill Kit | GitHub issue in `chrislacey89/skills` with repo-wide improvement proposal | Review issue, then optional implementation in `chrislacey89/skills` |
 | `/ubiquitous-language` | Terminology ambiguity or competing domain terms | `UBIQUITOUS_LANGUAGE.md` with decisions register | Returns to the caller workflow |
 | `/ts-audit` | TypeScript or React files to audit | Structured findings report grouped by category | `/execute` or `/pre-merge` |
+| `/walk-commits` | Finished branch ready to merge, plus the base branch to diff against | Reviewer comprehension and per-commit sign-off (🟢/🟡/🔴) with open items to resolve — a decision, not a durable file | Merge, then `/compound` only when a durable lesson emerged |
 | `/help` | Uncertainty about current pipeline position | Next-step recommendation with a one-line reason | The recommended next skill |
 | `/correct-course` | Invalidated artifact or changed assumption | Blast-radius diagnosis and artifact cleanup plan | The earliest skill that needs to re-run |
 | `/handoff` | Long session with no natural compression artifact — mid-skill, exploratory, side-route, or non-pipeline work | Transient handoff doc at a `mktemp` path; references existing artifacts by path, URL, or issue number | Fresh session opened by the user with the doc as input |
@@ -320,6 +321,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 - `/request-refactor-plan` and `/improve-codebase-architecture` produce refactor work that can re-enter at `/execute`
 - `/improve-pipeline` captures Skill Kit improvement proposals as GitHub issues in `chrislacey89/skills`, then optionally flows into reviewed implementation of the named repo changes
 - `/ts-audit` produces type-safety findings that can feed into `/execute` for fixes or inform `/pre-merge` architectural review
+- `/walk-commits` is an optional commit-by-commit comprehension walkthrough at the `/pre-merge` → merge boundary; `/pre-merge` Phase 4 recommends it (without invoking) when the person merging didn't author the diff, and `/execute` Step 5/6 names it as an option before `/pre-merge`. It produces reviewer comprehension and sign-off, not defect findings, and never auto-runs
 - `/help` reads repo state and recommends the next pipeline skill with a one-line reason — advisory only, never runs the next skill itself
 - `/correct-course` diagnoses stale artifacts when an upstream assumption fails, walks the cleanup, and hands off to the earliest skill that needs to re-run
 - `/handoff` is invoked ad-hoc when no inter-skill compression artifact covers the situation (mid-skill, exploratory, non-pipeline work, or cross-machine/cross-agent handoff); it is not part of any default path and is not a substitute for the `**Next session:**` runtime line primary skills already emit
@@ -381,6 +383,7 @@ One row per skill. For quick orientation — what each skill expects, what it pr
 ├── ts-audit/                       # Audit TypeScript code against Total TypeScript library references
 │   ├── SKILL.md
 │   └── evals/
+├── walk-commits/SKILL.md           # Interactive commit-by-commit comprehension walkthrough before merge (optional, recommended by /pre-merge)
 ├── help/SKILL.md                   # Read repo state and recommend the next pipeline skill (advisory only)
 └── correct-course/SKILL.md         # Diagnose stale artifacts and walk the cleanup when an upstream assumption fails
 ```
@@ -437,6 +440,7 @@ Do **not** introduce a committed `progress.txt` file in this repo. Ralph's durab
 | Write tests first | `/tdd` for strict red-green-refactor, usually delegated from `/execute` |
 | Run a QA session or report bugs | `/qa` — single entry point for bug conversations; files lightweight GitHub issues in domain language and delegates per-issue to `/triage-issue` when a specific bug needs root-cause diagnosis |
 | Review and create PR before merge | `/pre-merge` — creates PR with PRD lineage, runs architectural review |
+| Understand a branch commit-by-commit before merging it | `/walk-commits` — interactive per-commit walkthrough (intent, riskiest line, deliberate oddities, what's absent by design) with 🟢/🟡/🔴 sign-off; optional, recommended by `/pre-merge`, distinct from its defect review |
 | Improve Skill Kit itself | `/improve-pipeline` — capture a pipeline-level lesson as a GitHub issue in `chrislacey89/skills` after loading canonical Skill Kit context |
 | Investigate a specific bug deeply | Start with `/qa` — its Step 3.5 depth check delegates to `/triage-issue` for root-cause analysis, structural diagnosis, and a TDD fix plan that flows into `/execute` |
 | Plan a refactor | `/request-refactor-plan` — tiny commits RFC as GitHub issue, then implement via `/execute` |

--- a/walk-commits/SKILL.md
+++ b/walk-commits/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: walk-commits
+description: "Side-route skill for an interactive, commit-by-commit comprehension walkthrough of a finished branch before merge. Use when the person about to merge didn't author the diff — or hasn't internalized it — and needs to understand each commit's intent, riskiest line, deliberate oddities, and what's absent by design, with per-commit sign-off. Not a defect finder (that's /pre-merge), not a behavioral check (that's /verify), not an acceptance-criteria checklist (that's /execute Step 5). Optional and never auto-invoked."
+sources:
+  primary:
+    - "Code Reading: The Open Source Perspective — Diomidis Spinellis"
+  secondary:
+    - "Best Kept Secrets of Peer Code Review — Jason Cohen"
+    - "Peer Review on Open-Source Software Projects — Peter C. Rigby"
+---
+
+# Walk Commits
+
+Walk the person about to merge a branch through it commit by commit, so they actually understand what they are shipping. The output is *reviewer comprehension and a sign-off decision*, not a defect list. For each commit you narrate the author's intent (not a restatement of the diff), anchor the single riskiest line, surface the choices that look odd on purpose, name what is absent by design, and flag anything needing the merger's explicit sign-off — then let them step to the next commit.
+
+This skill exists because the highest-leverage finding in Cohen's peer-review dataset is *author preparation*: an annotated change walked through by a prepared narrator correlates with near-zero defect variance. The pipeline produces that annotation nowhere else. `/pre-merge` finds defects across the whole diff; `/verify` runs the app; `/execute` Step 5 checks acceptance criteria. None of them narrate the change commit-by-commit for the human who clicks merge.
+
+## Invocation Position
+
+This is a **side-route skill**. It does not block merge and is never auto-invoked.
+
+It reconnects to the main pipeline at the `/pre-merge` → merge boundary: run it when you want comprehension before approving, then proceed to merge (and `/compound` if a durable lesson emerged). `/pre-merge` Phase 4 *recommends* it (without invoking it) when the person merging did not author the diff or hasn't internalized it; `/execute` Step 5/6 names it as an option before `/pre-merge` from the author side.
+
+Use `/walk-commits` when:
+
+- You are about to merge a branch you did not write, or wrote long enough ago that you no longer hold it in your head.
+- A reviewer needs to genuinely understand a change before approving it — not just confirm tests pass.
+- You want the comprehension pass to be repeatable and consistent, rather than a prompt you retype every session.
+
+Do not use `/walk-commits`:
+
+- To find defects across the whole diff — that is `/pre-merge`'s adversarial, dimension-based review.
+- To confirm the feature behaves correctly at runtime — that is `/verify`.
+- To check acceptance criteria — that is `/execute` Step 5's checklist.
+- To draft review comments on someone else's open PR — that is `/pre-merge --pr <n>` reviewer-mode.
+
+The line that keeps this distinct from `/pre-merge`: **comprehension and sign-off, not defect-finding.** If you catch yourself enumerating bugs across files, you are running the wrong skill.
+
+## The reading discipline (why this stays small)
+
+Cohen and Rigby both cap effective review at roughly **100–300 LOC and 30–60 minutes** — past that, fatigue degrades comprehension and the walkthrough becomes the rubber-stamp it was meant to prevent. Spinellis supplies the epistemic reason: **minimal comprehension** — read selectively, with a goal, and stop when you understand *enough to sign off*, not when you have read every line. The walkthrough reads selectively per commit toward a goal; it never marches line-by-line through 800 lines.
+
+**If the diff is oversize** (well past ~300 LOC of meaningful change, or many commits), do not power through in one sitting. Recommend chunking the walkthrough across sittings — by logical group of commits, or by subsystem — and say so explicitly before starting. A tired walkthrough is worse than no walkthrough.
+
+## Process
+
+### 1. Establish the range and give the overview first
+
+Resolve the commit range to walk — the commits on this branch not yet on the base branch:
+
+```bash
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null | sed 's@^origin/@@')
+[ -z "$BASE_BRANCH" ] && for c in main master prod trunk; do git rev-parse --verify "$c" >/dev/null 2>&1 && BASE_BRANCH=$c && break; done
+git log --oneline --no-merges "$BASE_BRANCH..HEAD"
+git diff --stat "$BASE_BRANCH..HEAD"
+```
+
+Do not hardcode `main` — detect the base (this repo itself uses `prod`). If the range is empty or the base can't be resolved, ask the user which range to walk.
+
+Then present an **overview before the first commit** (Spinellis: *overview first*). It is short and does two jobs:
+
+- **State the scale and apply the budget.** Total commits, total changed LOC, files touched. If it exceeds the 100–300 LOC / 30–60 min budget, recommend chunking now (see "The reading discipline" above).
+- **Declare the reading mode** (Spinellis: *reading mode determines strategy*). Most branches are one of:
+  - **Evolution** — adding or changing behavior. Strategy: find the exemplar commit, read backward from the call sites the diff touches, scope comprehension to interface contracts.
+  - **Maintenance** — fixing a defect. Strategy: anchor on the symptom, trace manifestation → source, ignore unrelated paths.
+
+  Naming the mode picks how each commit gets read. State which one this branch is and why.
+
+### 2. Walk each commit
+
+Loop over the commits **in order**. For the current commit, read it with `git show <hash>` and produce the per-commit card below. Keep it tight — no padding, no diff restatement.
+
+Derive **intent** with Spinellis's *five-strategy function understanding*, cheapest-first — stop at the first source that suffices:
+
+1. commit subject → 2. symbol name → 3. **the call sites the diff touches** → 4. the body → 5. tests / docs.
+
+Read the body only when the name and call sites fail to explain the change. This makes "intent" a disciplined derivation, not a paraphrase of the hunk.
+
+Pick the **single riskiest line** with Spinellis's *surface-signal scan* — a catalog for where to point:
+
+- canonical-`for` deviation (`<=`, non-zero start) → likely off-by-one
+- `[lower, upper)` half-open-range misread
+- push/pop or **mutex acquire/release asymmetry on error paths**
+- empty `catch` with no comment
+- missing `static` / over-broad visibility
+- `FALLTHROUGH` omission in a switch
+- an unclassifiable pointer or `any`
+- a high-churn file (many recent touches → fragile)
+
+Anchor it as `file:line` so the user can click straight to it.
+
+Surface **intentional-looking-odd choices** with Spinellis's *deviation = signal*: any departure from a canonical form demands an explicit "why." Either the author intended it (and the walkthrough states the reason) or it is a bug. The deleted `enabled=true` filter that turns out to be the *point* of the change lives here — it looks like an omission but is the intent.
+
+Name **things absent by design** by classifying each apparent omission (Spinellis): **justified** (deliberate, explained), **careless** (a real gap), or **malicious** (hidden). Forcing the classification stops the merger from glossing over a missing test, a skipped error path, or an unhandled state.
+
+Decide **sign-off items** against the *documentation trust hierarchy* (Spinellis): tests and assertions outrank revision logs, which outrank comments, which outrank prose. Verify stated intent against the **added test** — the most executable evidence — not the commit message. A commit whose claimed behavior has no test backing it is a 🟡 at best.
+
+Mark each commit 🟢 / 🟡 / 🔴:
+
+- 🟢 understood, intent verified against executable evidence, sign-off clear
+- 🟡 understood but carries an open question, a thin test, or a deliberate oddity worth confirming
+- 🔴 not yet understood, or the diff contradicts the stated intent — do not sign off
+
+#### Per-commit card
+
+```
+### <short-hash> — <commit subject>   🟢|🟡|🔴
+**Files:** <the files this commit touches>
+**Intent:** <why this change exists, derived cheapest-first — not a diff restatement>
+**Riskiest line:** `path/to/file.ts:NN` — <what to watch and why it is the riskiest>
+**Looks odd on purpose:** <deliberate deviations and the reason — or "none">
+**Absent by design:** <omissions, each classified justified / careless / malicious — or "none">
+**Sign-off:** <what the merger must confirm; cite the test that backs the intent, or note its absence>
+```
+
+Omit a line when it genuinely has nothing (e.g. "Looks odd on purpose:" on a boring commit) — empty scaffolding is padding.
+
+### 3. Step the loop with AskUserQuestion
+
+After each commit's card, advance the walkthrough with a single `AskUserQuestion` (one question per turn — never a menu of separate questions). Offer:
+
+- **Next commit** — proceed to the following commit.
+- **2–3 commit-specific deep-dives** — concrete, drawn from *this* commit (e.g. "Show the test that backs commit 3's claim," "Read the call sites of the renamed export," "Confirm the `"use server"` boundary with a `next build`").
+
+When a commit is opaque, do **not** deep-recurse line by line. Take Spinellis's *breadth-first escape* and use **execution as a reading tool**: read the test as the spec, try another call site, or escalate to a `next build` / `/verify`. PR-level example: a migrated `"use server"` action with a new injectable `db` param was confirmed by a build, not by staring at the diff. Naming this as a legitimate reading move keeps comprehension moving instead of stalling.
+
+### 4. Wrap up after the last commit
+
+After the final commit, offer a wrap-up via `AskUserQuestion`:
+
+- A one-screen summary: per-commit 🟢/🟡/🔴 roll-up and the open 🟡/🔴 items the merger still needs to resolve before merging.
+- Whether to proceed to merge, or to pause on the unresolved items.
+
+If any commit is still 🔴, say plainly that the branch is not yet understood well enough to sign off, and name what is unresolved. The skill's job is honest comprehension, not a green light.
+
+## What This Skill is NOT
+
+- **Not a defect review.** It does not sweep the whole diff for bugs across dimensions — `/pre-merge` does that and emits advisory findings.
+- **Not a behavioral check.** It does not run the app — `/verify` does that.
+- **Not an acceptance-criteria checklist.** That is `/execute` Step 5.
+- **Not a mandatory stage.** It is optional, invoked only when wanted, and never auto-runs. If a future sample of PRs shows it is rarely invoked or only fires on diffs `/pre-merge` already covered, fold it back into `/pre-merge` as an optional phase.
+- **Not a rubber stamp.** Clicking "Next commit" without absorbing each card defeats the point. The 🟢/🟡/🔴 sign-off and the test-backed intent check are the structural guards against that.
+
+## Handoff
+
+- **Expected input:** a finished branch ready to merge, plus the base branch to diff against. No upstream artifact is required, though a linked PRD or slice issue helps frame intent.
+- **Produces:** reviewer comprehension and a per-commit sign-off (🟢/🟡/🔴) with the open items the merger must resolve — a decision, not a durable file. It does not create issues, post comments, or edit code.
+- **Reconnects at:** the `/pre-merge` → merge boundary. Run it before approving; proceed to merge once commits are understood, then `/compound` if a durable lesson emerged.
+- **What comes next:** the user merges (or pauses on unresolved 🔴/🟡 items). `/walk-commits` does not invoke anything.


### PR DESCRIPTION
## Summary

Skill Kit hands the person about to merge a finished branch two review tools — `/pre-merge` (an adversarial, whole-diff defect review across 11 dimensions) and `/verify` (run the app and watch behavior) — but neither walks them through the change *commit by commit* so they actually understand what they're shipping. As issue #103 documents, the operator had been hand-retyping the same bespoke walkthrough prompt every session; on `fulcrum#242` it surfaced things a whole-diff review glosses (a `"use server"` action's new injectable `db` param needing a build check; a deleted `enabled=true` filter that *was* the point of the change). The highest-value review behavior of the last several days had no home — it lived in a copy-pasted prompt.

This PR gives that behavior a home: a new **`/walk-commits`** side-route skill. It walks each commit in order and, per commit, narrates the author's intent (derived cheapest-first, not a diff restatement), anchors the single riskiest `file:line`, surfaces choices that look odd on purpose, names what's absent by design, and flags sign-off items — marking each 🟢/🟡/🔴 and stepping with `AskUserQuestion`. The output is *reviewer comprehension and a sign-off decision*, not a defect list.

The skill's internal mechanics operationalize Spinellis's *Code Reading* (reading-mode declaration, the name→call-site→body intent ladder, the surface-signal catalog behind "riskiest line", deviation-as-signal, justified/careless/malicious omission classification, the documentation trust hierarchy, breadth-first escape), bounded by Cohen/Rigby's 100–300 LOC / 30–60 min size discipline. Per the issue's Mediator verdict it is **optional and never auto-invoked** — `/pre-merge` Phase 4 *recommends* it (kept distinct from the defect review) and `/execute` Step 5 names it as an option from the author side. The sharp purpose line — *comprehension and sign-off, not defect-finding* — is what keeps it from eroding the `/pre-merge` boundary.

## PRD

Closes #103

## Key Decisions

- **Optional side-route, not a mandatory stage or a `/pre-merge` mode** — directly per the issue's Mediator "Proceed narrowly" verdict; neutralizes the Skeptic's featuritis/policy-resistance objection.
- **Registered across all discovery surfaces** to avoid skill-list drift: SYSTEM-OVERVIEW.md (all 5 enumerations + the 4 synced bundled copies via `scripts/sync-skill-references.sh`), README (Knowledge & QA row), and — beyond the issue's table — **CLAUDE.md's** side-route Invocation Roles list, since leaving it stale is the exact drift the Mediator flagged.
- **README skill count bumped 26 → 27** (not in the issue's change table, but adding a skill without it is advertised-count drift).
- **`sources` frontmatter added** (primary: Spinellis; secondary: Cohen, Rigby) — the skill makes substantive methodological claims that CLAUDE.md says warrant provenance.
- The single comment on #103 (a Spinellis→heuristic mapping authored by the owner) was audited: it is already folded into the issue body and was used as the spec for the skill's reading mechanics — no scope override.
