### PR TITLE
walk-commits: cue cross-hunk symbol-replacement in surface-signal scan

### DIFF
--- a/walk-commits/SKILL.md
+++ b/walk-commits/SKILL.md
@@ -86,8 +86,9 @@ Pick the **single riskiest line** with Spinellis's *surface-signal scan* — a c
 - `FALLTHROUGH` omission in a switch
 - an unclassifiable pointer or `any`
 - a high-churn file (many recent touches → fragile)
+- a symbol **removed in one hunk and re-added — same name or renamed — elsewhere with a changed signature, return type, or lifecycle**: a function replaced by a structurally-evolved successor. The unified diff splits one evolving thing into a delete hunk and an add hunk and hides that callers now depend on a new contract; read the new shape against the old, not as two unrelated edits.
 
-Anchor it as `file:line` so the user can click straight to it.
+Anchor it as `file:line` so the user can click straight to it. **Detecting the replaced-symbol case:** when a commit shows a large deletion of a symbol and a large addition elsewhere, check whether they are the same logical unit (rename detection, `git log --follow`, or matching call sites) before treating them as independent edits — then carry the finding through the existing Riskiest-line / Looks-odd-on-purpose / Absent-by-design card lines (no new card line needed).
 
 Surface **intentional-looking-odd choices** with Spinellis's *deviation = signal*: any departure from a canonical form demands an explicit "why." Either the author intended it (and the walkthrough states the reason) or it is a bug. The deleted `enabled=true` filter that turns out to be the *point* of the change lives here — it looks like an omission but is the intent.
 


### PR DESCRIPTION
## Summary

`/walk-commits` walks a merger through a branch commit-by-commit so they understand what they're shipping. Its Step 2 "surface-signal scan" catalog — borrowed from Spinellis's *deviation = signal* — tells the narrator where to point for the single riskiest line, but it only listed *intra-line* smells (off-by-one, half-open ranges, mutex asymmetry, empty catch). It had no entry for the highest-comprehension-risk *cross-hunk* shape: a function removed in one hunk and re-added (same name or renamed) elsewhere with a changed signature, return type, or lifecycle. The unified diff actively disguises that one-thing-evolving as two unrelated edits and hides the new caller contract, so on a less-careful pass a changed function contract can reach merge un-internalized — precisely the failure the skill exists to prevent.

This adds one catalog bullet for that pattern plus a one-line detection heuristic (pair a large deletion with a same/renamed re-addition via rename detection / `git log --follow` / matching call sites). Per the issue's Mediator verdict, it deliberately routes the finding through the existing card lines and does **not** add a new required card line — the six-line per-commit card is unchanged (Gawande item-budget).

## PRD

Closes #118

## Key Decisions

- No new card slot (Non-Goal): the cue lives in the existing Spinellis-derived catalog and surfaces via Riskiest-line / Looks-odd-on-purpose / Absent-by-design.
- `/pre-merge` untouched — this is comprehension discipline, not defect review; no duplication.