### PR TITLE
prototype/prd-to-issues: preserve reusable spike-captured output (#119)

### DIFF
--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -232,6 +232,8 @@ Mark quality-attribute criteria with `[QA-<attribute>]` where `<attribute>` is o
 
 List the 3-5 key assumptions from the parent PRD that this slice depends on. Before starting execution, spend 60 seconds confirming each is still true. If any assumption has changed, this slice gets a targeted `/research` → mini-PRD cycle before proceeding. If all hold, execute directly.
 
+**Caution — spike artifacts vs. spike verdicts.** If an assumption depends on a spike's captured *artifact* (recorded responses, sample payloads, challenge-page HTML, golden files the slice will commit as a fixture) rather than the spike's *verdict*, do not assert it is "still available" — `/prototype` deletes spikes by default, so the artifact is gone unless it was deliberately preserved (committed as a fixture or recorded as a re-capture recipe; see `/prototype` "Preserve reusable captured output"). Confirm the artifact was actually persisted before writing the assumption. If it was not, scope the slice to re-capture the artifact rather than asserting it persists — otherwise the assumption is false the moment it is written and only `/execute`'s Assumptions-validation gate catches it, late and mid-flight.
+
 - [ ] [Assumption 1 — e.g., "Turso free tier still provides 5GB storage"]
 - [ ] [Assumption 2 — e.g., "better-sqlite3 is still the Drizzle driver in use"]
 - [ ] [Assumption 3 — e.g., "Vercel auto-detects TanStack Start"]

--- a/prototype/SKILL.md
+++ b/prototype/SKILL.md
@@ -37,10 +37,19 @@ If the question is genuinely ambiguous and the user isn't reachable, default to 
 3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is *checking*, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
 4. **Skip the polish.** No tests beyond the spike's own assertion (FEASIBILITY only), no error handling beyond what makes the prototype *runnable*, no abstractions. The point is to learn something fast and then delete it.
 5. **Surface the state or the verdict.** LOGIC re-renders state after every action; UI shows the variant on every switch; FEASIBILITY emits a pass/fail verdict from the test runner or a single observable outcome from the scratch route.
-6. **Delete or absorb when done.** When the prototype has answered its question, either delete it or fold the validated decision into the real code — don't leave it rotting in the repo. For FEASIBILITY specifically, the spike is deleted in the same change that captures the verdict; the verdict is what persists, not the spike.
+6. **Delete or absorb when done.** When the prototype has answered its question, either delete it or fold the validated decision into the real code — don't leave it rotting in the repo. For FEASIBILITY specifically, the spike is deleted in the same change that captures the verdict; the verdict is what persists, not the spike. *Carve-out:* when the spike's captured **output** (not its verdict) is a foreseeable downstream asset — a later slice will consume it as a test fixture — preserve that artifact deliberately; see "Preserve reusable captured output" under **When done**.
 
 ## When done
 
 The *answer* is the only thing worth keeping from a prototype. Capture it somewhere durable (commit message, ADR, issue, the research artifact's assumption tag, or a `NOTES.md` next to the prototype) along with the question it was answering. If the user is around, that capture is a quick conversation; if not, leave the placeholder so they (or you, on the next pass) can fill in the verdict before deleting the prototype.
 
 For FEASIBILITY spikes specifically, the verdict folds back into the calling skill's artifact: `/research` downgrades the assumption tag (e.g. `Uncertain` → `Verified` or `Refuted`), and `/execute` proceeds, pivots, or files a `/correct-course` depending on the answer.
+
+### Preserve reusable captured output
+
+The verdict is always what persists; the spike itself is disposable scaffolding by default, and most spike output genuinely is — delete it. But a FEASIBILITY spike sometimes captures **output** that is itself the cheapest source of a downstream asset: recorded HTTP responses, sample payloads, challenge-page HTML, golden files. When such output is a *foreseeable* downstream consumer's input — a later slice will commit it as a test fixture — preserve that artifact deliberately, distinct from and in addition to the verdict. Either:
+
+- **Commit it as a fixture now** in its real home (e.g. `fixtures/`), with a one-line note on where it came from and when, so the consuming slice's "captures available" assumption is *true* rather than caught-false at execution time; or
+- **Record the exact re-capture recipe** alongside the verdict (the command, the source, any auth/IP conditions) when the artifact can't or shouldn't be committed, so the slice can regenerate it deterministically instead of re-deriving how.
+
+This is a narrow exception, not a license to hoard. Preserve only when a *named* downstream consumer makes the output an asset; verdict-only discipline stays the default for ordinary spikes (Rule 6), where preserving output speculatively just bloats the repo with stale captures. The signal you preserve here is what `/prd-to-issues` and `/execute` rely on when a slice's assumption depends on a spike artifact rather than its verdict.


### PR DESCRIPTION
## Summary

`/prototype`'s FEASIBILITY discipline deletes a spike in the same change that records its verdict — "the verdict is what persists, not the spike." That rule has a blind spot: sometimes a spike's *captured output* (recorded HTTP responses, sample payloads, challenge-page HTML, golden files) is itself the cheapest source of a downstream test fixture, not just scaffolding behind the verdict. When the spike deletes that output and a later slice's "captures still available" assumption depends on it, the assumption is **false the moment it is written** — and only `/execute`'s Assumptions-validation gate catches it, late and mid-flight (the field incident in #119, mimir crawler PR #17).

This closes the missing feedback loop with two small, coordinated edits — disposable-by-default stays the rule; preservation is a narrow, conditional carve-out triggered only when a *named* downstream consumer makes the output an asset (Meadows: fix the structure, a carried signal, not "remember to check").

- **`prototype/SKILL.md`** — new "Preserve reusable captured output" subsection under *When done*, with an inline flag on Rule 6. When a spike's captured output is a foreseeable downstream fixture, preserve it deliberately: commit it as a fixture now, or record the exact re-capture recipe — distinct from and additional to the verdict.
- **`prd-to-issues/SKILL.md`** — caution in *Assumptions from Parent PRD*: an assumption depending on a spike *artifact* (vs. its verdict) must confirm the artifact was actually persisted, since `/prototype` deletes spikes by default; otherwise scope the slice to re-capture rather than asserting "still available."

## PRD

Closes #119

## Key Decisions

- Followed the issue's Mediator verdict ("Proceed narrowly"): the carve-out is *conditional*, gated on a foreseeable named consumer, and does not weaken verdict-only discipline for ordinary spikes.
- `/execute`'s Assumptions-validation gate (the backstop that caught the original incident) is intentionally left unchanged — it is the safety net, not the fix.