### PR TITLE
ts-audit: redact secrets before quoting code in the report (#124)

### DIFF
--- a/ts-audit/SKILL.md
+++ b/ts-audit/SKILL.md
@@ -171,6 +171,15 @@ The goal of this second pass is to surface at least 1-2 findings per loaded libr
 
 ## Step 4: Generate the report
 
+### Redact secrets before writing the report
+
+The report quotes source code verbatim, and it is a portable artifact — users paste it into a PR, drop it in chat, or hand it to another agent. Source files routinely carry secrets, so masking is not optional and not best-effort: run this pass on every snippet *before* it goes into the report.
+
+- Mask the *value* of any line matching a high-signal secret shape — `*_KEY`, `*_SECRET`, `*_TOKEN`, `*_PASSWORD`, `AKIA…`, `sk-…`, `ghp_…`, `xox[baprs]-…`, bearer tokens, `postgres://user:pass@…` and other credentialed URIs, PEM blocks.
+- Keep the *key*, mask the value — `STRIPE_SECRET_KEY=sk_live_••••••••` keeps the finding legible without leaking the credential. The type pattern is what the finding is about; the secret is not.
+- When in doubt, redact. A masked line the reader can ask about is recoverable; a leaked one in a copied report is not.
+- If you masked anything, say so once near the top of the report ("N value(s) masked") so the reader knows the artifact is sanitized, not incomplete.
+
 Structure the report as markdown:
 
 ```markdown
@@ -207,7 +216,7 @@ _Source: <library book name(s)>_
 **Grouping:** by category (Type Safety, Generics, etc.), not by file. Within each category, order findings by file path then line number.
 
 **What to include in each finding:**
-- The actual code snippet (keep it focused — just the relevant lines)
+- The actual code snippet (keep it focused — just the relevant lines), with secret values masked per the redaction step above
 - A concrete suggested replacement, not just "consider using X"
 - A brief explanation referencing the specific concept from the library
 


### PR DESCRIPTION
## Summary

`/ts-audit` reads a user's TypeScript source and writes a markdown report that quotes the offending code for each finding. That report is a portable artifact — it gets pasted into PRs, dropped in chat, and handed to other agents. Source files routinely carry secrets (a `STRIPE_SECRET_KEY` constant, a `postgres://user:pass@…` string in a fixture, a bearer token in a fetch wrapper), so when the skill quoted a line verbatim, the secret traveled with the report. An external Snyk audit of the published skill graded this **HIGH / Failed** (W007, insecure credential handling), and nothing in the skill told the agent to redact anything.

This adds an output-side redaction step to Step 4: before any snippet goes into the report, mask the *value* of lines matching high-signal secret shapes, keep the *key* so the finding stays legible, and note once near the top if anything was masked. It mirrors the redaction discipline the repo already established for the visual skills in `docs/visual-rendering-core.md` § 2 — same hazard (a portable artifact that quotes source), same fix.

Kept deliberately narrow per the #124 Mediator verdict: the redaction *rules* are inlined as a short, self-contained block rather than extracted into a shared doc and bundled. The visual doc's redaction is diff-shaped; ts-audit's is arbitrary-source-shaped — related but not identical, and only two consumers share the visual version today, so the Rule of Three for extraction isn't met. No `scripts/skill-references.manifest` change, no shared-reference bundle.

**Why it matters:** it closes a HIGH security finding on a published skill and stops `/ts-audit` from leaking credentials into a copy/pasted report, without adding cross-skill coupling.

## PRD

Closes #124

## Key Decisions

- Inlined the redaction rules instead of extracting a shared `docs/secret-redaction.md` (Rule of Three not yet met; the two redaction shapes differ).
- No manifest/bundled-reference change — keeps the skill self-contained per `CLAUDE.md` and avoids a `sync-skill-references.sh` dependency.
