### PR TITLE
visual-recap §5: frame-fill embedded Mermaid + label-safety/render-confirm (#128, #129)

### DIFF
--- a/docs/visual-recap-design.md
+++ b/docs/visual-recap-design.md
@@ -120,6 +120,11 @@ works fully offline). These variable names are the canonical set; do not rename 
   .vr-marker{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;
     border:none;background:var(--accent);color:#fff;font-weight:700;font-family:var(--sans);cursor:pointer}
   .vr-marker.is-active{box-shadow:0 0 0 3px var(--accent-dim)}
+
+  /* Embedded Mermaid sizes to its frame, never its intrinsic size. CSS-first and
+     offline-safe — this rule alone fixes the too-small diagram even with the network off
+     (the §5 Mermaid-init script is enhancement-only). */
+  .mermaid svg{width:100%;max-width:100%;height:auto;display:block}
 </style>
 ```
 
@@ -242,17 +247,62 @@ links to its hunk in §6. The five flag hues are fixed: `new` `moved` `load-bear
 
 When topology needs a picture, **reuse `/mermaid`** and embed the result in this frame — do
 not hand-roll graph layout (Skill Kit chose embedded Mermaid as its diagram answer, #83).
+`/visual-recap` (and `/walk-commits`) can invoke `/mermaid` directly to produce the source;
+prefer that for any non-trivial diagram (see the label-safety note below).
+
+The container is a **full-width block** (not flex-centered) and the `.mermaid svg` rule from
+§1 stretches the diagram to fill it. The `<pre class="mermaid">` carries the diagram source —
+which is also the offline fallback: with the network off (no Mermaid CDN) it renders as
+readable source text rather than a blank frame.
 
 ```html
 <section id="sec-diagram" style="margin-top:var(--s8);scroll-margin-top:var(--s7)">
   <div style="font-size:11px;font-weight:600;letter-spacing:.16em;text-transform:uppercase;color:var(--fg-faint);margin-bottom:var(--s4)"><span style="font-family:var(--mono);color:var(--accent)">03</span> &nbsp;Diagram</div>
   <figure style="margin:0">
-    <div style="border:1px solid var(--border);border-radius:var(--r3);background:var(--bg-elev);box-shadow:var(--shadow);padding:var(--s8) var(--s6);display:flex;align-items:center;justify-content:center">
-      <!-- embed the generated Mermaid SVG/markup here -->
+    <div style="border:1px solid var(--border);border-radius:var(--r3);background:var(--bg-elev);box-shadow:var(--shadow);padding:var(--s8) var(--s6);overflow:auto">
+      <!-- Diagram source AND offline fallback. Mermaid (if loaded) replaces this with an
+           SVG that the §1 `.mermaid svg` rule sizes to the frame. Quote every label. -->
+      <pre class="mermaid" style="margin:0;font-family:var(--mono);font-size:12px;color:var(--fg-muted)">
+flowchart LR
+  A["session.ts"] -->|"reads token"| B["tokenStore.get()"]
+  B --> C["middleware/authGuard"]
+      </pre>
     </div>
     <figcaption style="margin-top:var(--s3);font-size:12px;color:var(--fg-muted)">Fig 1 · one-line caption.</figcaption>
   </figure>
 </section>
+```
+
+**Label-safety (hand-authored Mermaid).** Mermaid's label grammar is unforgiving; a faithful
+copy that ignores it ships a parse-error box instead of a diagram. When you write source by
+hand:
+
+- **Quote every node and edge label** — `A["text"]`, `A -->|"text"| B`. Quoting neutralizes
+  the characters below.
+- **Never leave raw `[ ] # ( ) { }` inside an *unquoted* label.** `[`/`]` are read as
+  node-shape syntax; a bare `#` begins an HTML entity code (so `#23` breaks — write
+  `"slice 23"`); `(` opens a round-node. Quote the label or rephrase.
+- **No literal `<br/>` inside an unquoted label** — wrap the label in quotes first.
+- **For any non-trivial diagram, author it via `/mermaid`** instead of hand-writing source.
+  `/mermaid` has its own render-verification step (#94), so it catches these before the
+  source reaches the artifact — the safer path the render-confirm gate (core §7) points at.
+
+**Frame-filling render (enhancement-only; CDN per §6).** The `.mermaid svg` CSS rule already
+sizes the diagram offline-first. When the Mermaid CDN is available, initialize it with
+`flowchart.useMaxWidth:false` and run a post-render pass so the SVG fills the frame rather
+than rendering at its intrinsic (tiny) size. This is enhancement-only — it must never replace
+the `<pre class="mermaid">` source-text fallback above:
+
+```html
+<!-- enhancement-only: omit and the diagram still reads as source text offline (§6) -->
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, flowchart: { useMaxWidth: false } });
+  addEventListener('load', () => document.querySelectorAll('.mermaid svg').forEach(svg => {
+    svg.removeAttribute('width'); svg.removeAttribute('height');   // drop intrinsic sizing;
+    svg.style.width = '100%'; svg.style.height = 'auto';           // let §1's rule fill the frame
+  }));
+</script>
 ```
 
 ---

--- a/docs/visual-rendering-core.md
+++ b/docs/visual-rendering-core.md
@@ -143,6 +143,7 @@ The diff and its callouts are the data; everything else recedes.
 - **Small multiples + constancy of design** for before/after and per-file panels: identical scale, identical frame on both sides, so the eye reads the *difference*, not a layout change. Never restyle the after-side relative to the before-side.
 - **Subtraction of weight (1 + 1 = 3).** Adjacent heavy borders create phantom third shapes that read as content. Prefer whitespace and a single light rule to separate panels; delete every border that is not doing work.
 - **Value-scale semantic color, checked for simultaneous contrast in both themes.** Add/remove and risk colors must hold their meaning and contrast on light *and* GitHub-dark backgrounds — flip the palette on `[data-theme]`, and verify red/green stay legible against each other and the background (the principled answer to the #94 dark-mode contrast concern: a value scale, not a one-off patch).
+- **A diagram fills its frame.** Never render an embedded Mermaid SVG at its intrinsic size; size it to the column width (CSS-first, offline-safe — `.mermaid svg{width:100%;height:auto}`, per the `visual-recap-design.md` §1/§5 skeleton). A tiny centered diagram starves the data-ink the section exists to show.
 - **Respect the reading budget** (Cohen / Rigby: ~100–300 LOC, 30–60 min, <400–500 LOC/hr). The recap is *author preparation*, so it must itself stay inside the budget: **3–8 key-change callouts, focused excerpts, not every hunk.** A recap that reproduces the whole diff has rebuilt the thing the reviewer was already going to scroll. If the change is too big for one budget, say so and recommend chunking — do not render a wall.
 
 ---
@@ -158,6 +159,15 @@ The artifact must read *identically* with no network. Proven by spike: a real re
 ---
 
 ## 7. Open / serve guidance the skill should emit
+
+**Confirm an embedded diagram renders before presenting (DO-CONFIRM).** If the recap embeds a
+Mermaid diagram, verify it renders without a parse error before handing the artifact to the
+reviewer — a quick load, or a re-check against the `visual-recap-design.md` §5 label-safety
+rules. The `<pre class="mermaid">` source fallback is *not* a substitute: it shows the source
+text, which is exactly what fails to parse. This is a lightweight verification, not a build
+dependency — it must not mandate a headless browser or erode the offline-first ethos (§6).
+For any non-trivial diagram, authoring it via `/mermaid` (which verifies its own render, #94)
+discharges this check up front.
 
 `file://` is a secure context in real browsers, so the simplest path is:
 

--- a/visual-recap/SKILL.md
+++ b/visual-recap/SKILL.md
@@ -100,6 +100,13 @@ Write the file to a **transient** path — gitignored `.context/` or `mktemp` �
 
 ### 5. Open, review, and round-trip the feedback
 
+If the recap embeds a Mermaid diagram, **confirm it renders without a parse error before
+presenting it** (a quick load, or a re-check against the `references/visual-recap-design.md`
+§5 label-safety rules). The `<pre class="mermaid">` source fallback shows source text — the
+exact thing that fails to parse — so it does not stand in for a rendering check. Authoring
+non-trivial diagrams via `/mermaid` (which verifies its own render) discharges this up front.
+Keep it lightweight — no headless-browser harness is required (core §7).
+
 Emit both open paths so the reviewer can choose:
 
 ```

--- a/visual-recap/references/visual-recap-design.md
+++ b/visual-recap/references/visual-recap-design.md
@@ -120,6 +120,11 @@ works fully offline). These variable names are the canonical set; do not rename 
   .vr-marker{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;
     border:none;background:var(--accent);color:#fff;font-weight:700;font-family:var(--sans);cursor:pointer}
   .vr-marker.is-active{box-shadow:0 0 0 3px var(--accent-dim)}
+
+  /* Embedded Mermaid sizes to its frame, never its intrinsic size. CSS-first and
+     offline-safe — this rule alone fixes the too-small diagram even with the network off
+     (the §5 Mermaid-init script is enhancement-only). */
+  .mermaid svg{width:100%;max-width:100%;height:auto;display:block}
 </style>
 ```
 
@@ -242,17 +247,62 @@ links to its hunk in §6. The five flag hues are fixed: `new` `moved` `load-bear
 
 When topology needs a picture, **reuse `/mermaid`** and embed the result in this frame — do
 not hand-roll graph layout (Skill Kit chose embedded Mermaid as its diagram answer, #83).
+`/visual-recap` (and `/walk-commits`) can invoke `/mermaid` directly to produce the source;
+prefer that for any non-trivial diagram (see the label-safety note below).
+
+The container is a **full-width block** (not flex-centered) and the `.mermaid svg` rule from
+§1 stretches the diagram to fill it. The `<pre class="mermaid">` carries the diagram source —
+which is also the offline fallback: with the network off (no Mermaid CDN) it renders as
+readable source text rather than a blank frame.
 
 ```html
 <section id="sec-diagram" style="margin-top:var(--s8);scroll-margin-top:var(--s7)">
   <div style="font-size:11px;font-weight:600;letter-spacing:.16em;text-transform:uppercase;color:var(--fg-faint);margin-bottom:var(--s4)"><span style="font-family:var(--mono);color:var(--accent)">03</span> &nbsp;Diagram</div>
   <figure style="margin:0">
-    <div style="border:1px solid var(--border);border-radius:var(--r3);background:var(--bg-elev);box-shadow:var(--shadow);padding:var(--s8) var(--s6);display:flex;align-items:center;justify-content:center">
-      <!-- embed the generated Mermaid SVG/markup here -->
+    <div style="border:1px solid var(--border);border-radius:var(--r3);background:var(--bg-elev);box-shadow:var(--shadow);padding:var(--s8) var(--s6);overflow:auto">
+      <!-- Diagram source AND offline fallback. Mermaid (if loaded) replaces this with an
+           SVG that the §1 `.mermaid svg` rule sizes to the frame. Quote every label. -->
+      <pre class="mermaid" style="margin:0;font-family:var(--mono);font-size:12px;color:var(--fg-muted)">
+flowchart LR
+  A["session.ts"] -->|"reads token"| B["tokenStore.get()"]
+  B --> C["middleware/authGuard"]
+      </pre>
     </div>
     <figcaption style="margin-top:var(--s3);font-size:12px;color:var(--fg-muted)">Fig 1 · one-line caption.</figcaption>
   </figure>
 </section>
+```
+
+**Label-safety (hand-authored Mermaid).** Mermaid's label grammar is unforgiving; a faithful
+copy that ignores it ships a parse-error box instead of a diagram. When you write source by
+hand:
+
+- **Quote every node and edge label** — `A["text"]`, `A -->|"text"| B`. Quoting neutralizes
+  the characters below.
+- **Never leave raw `[ ] # ( ) { }` inside an *unquoted* label.** `[`/`]` are read as
+  node-shape syntax; a bare `#` begins an HTML entity code (so `#23` breaks — write
+  `"slice 23"`); `(` opens a round-node. Quote the label or rephrase.
+- **No literal `<br/>` inside an unquoted label** — wrap the label in quotes first.
+- **For any non-trivial diagram, author it via `/mermaid`** instead of hand-writing source.
+  `/mermaid` has its own render-verification step (#94), so it catches these before the
+  source reaches the artifact — the safer path the render-confirm gate (core §7) points at.
+
+**Frame-filling render (enhancement-only; CDN per §6).** The `.mermaid svg` CSS rule already
+sizes the diagram offline-first. When the Mermaid CDN is available, initialize it with
+`flowchart.useMaxWidth:false` and run a post-render pass so the SVG fills the frame rather
+than rendering at its intrinsic (tiny) size. This is enhancement-only — it must never replace
+the `<pre class="mermaid">` source-text fallback above:
+
+```html
+<!-- enhancement-only: omit and the diagram still reads as source text offline (§6) -->
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, flowchart: { useMaxWidth: false } });
+  addEventListener('load', () => document.querySelectorAll('.mermaid svg').forEach(svg => {
+    svg.removeAttribute('width'); svg.removeAttribute('height');   // drop intrinsic sizing;
+    svg.style.width = '100%'; svg.style.height = 'auto';           // let §1's rule fill the frame
+  }));
+</script>
 ```
 
 ---

--- a/visual-recap/references/visual-rendering-core.md
+++ b/visual-recap/references/visual-rendering-core.md
@@ -143,6 +143,7 @@ The diff and its callouts are the data; everything else recedes.
 - **Small multiples + constancy of design** for before/after and per-file panels: identical scale, identical frame on both sides, so the eye reads the *difference*, not a layout change. Never restyle the after-side relative to the before-side.
 - **Subtraction of weight (1 + 1 = 3).** Adjacent heavy borders create phantom third shapes that read as content. Prefer whitespace and a single light rule to separate panels; delete every border that is not doing work.
 - **Value-scale semantic color, checked for simultaneous contrast in both themes.** Add/remove and risk colors must hold their meaning and contrast on light *and* GitHub-dark backgrounds — flip the palette on `[data-theme]`, and verify red/green stay legible against each other and the background (the principled answer to the #94 dark-mode contrast concern: a value scale, not a one-off patch).
+- **A diagram fills its frame.** Never render an embedded Mermaid SVG at its intrinsic size; size it to the column width (CSS-first, offline-safe — `.mermaid svg{width:100%;height:auto}`, per the `visual-recap-design.md` §1/§5 skeleton). A tiny centered diagram starves the data-ink the section exists to show.
 - **Respect the reading budget** (Cohen / Rigby: ~100–300 LOC, 30–60 min, <400–500 LOC/hr). The recap is *author preparation*, so it must itself stay inside the budget: **3–8 key-change callouts, focused excerpts, not every hunk.** A recap that reproduces the whole diff has rebuilt the thing the reviewer was already going to scroll. If the change is too big for one budget, say so and recommend chunking — do not render a wall.
 
 ---
@@ -158,6 +159,15 @@ The artifact must read *identically* with no network. Proven by spike: a real re
 ---
 
 ## 7. Open / serve guidance the skill should emit
+
+**Confirm an embedded diagram renders before presenting (DO-CONFIRM).** If the recap embeds a
+Mermaid diagram, verify it renders without a parse error before handing the artifact to the
+reviewer — a quick load, or a re-check against the `visual-recap-design.md` §5 label-safety
+rules. The `<pre class="mermaid">` source fallback is *not* a substitute: it shows the source
+text, which is exactly what fails to parse. This is a lightweight verification, not a build
+dependency — it must not mandate a headless browser or erode the offline-first ethos (§6).
+For any non-trivial diagram, authoring it via `/mermaid` (which verifies its own render, #94)
+discharges this check up front.
 
 `file://` is a secure context in real browsers, so the simplest path is:
 

--- a/walk-commits/references/visual-recap-design.md
+++ b/walk-commits/references/visual-recap-design.md
@@ -120,6 +120,11 @@ works fully offline). These variable names are the canonical set; do not rename 
   .vr-marker{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;
     border:none;background:var(--accent);color:#fff;font-weight:700;font-family:var(--sans);cursor:pointer}
   .vr-marker.is-active{box-shadow:0 0 0 3px var(--accent-dim)}
+
+  /* Embedded Mermaid sizes to its frame, never its intrinsic size. CSS-first and
+     offline-safe — this rule alone fixes the too-small diagram even with the network off
+     (the §5 Mermaid-init script is enhancement-only). */
+  .mermaid svg{width:100%;max-width:100%;height:auto;display:block}
 </style>
 ```
 
@@ -242,17 +247,62 @@ links to its hunk in §6. The five flag hues are fixed: `new` `moved` `load-bear
 
 When topology needs a picture, **reuse `/mermaid`** and embed the result in this frame — do
 not hand-roll graph layout (Skill Kit chose embedded Mermaid as its diagram answer, #83).
+`/visual-recap` (and `/walk-commits`) can invoke `/mermaid` directly to produce the source;
+prefer that for any non-trivial diagram (see the label-safety note below).
+
+The container is a **full-width block** (not flex-centered) and the `.mermaid svg` rule from
+§1 stretches the diagram to fill it. The `<pre class="mermaid">` carries the diagram source —
+which is also the offline fallback: with the network off (no Mermaid CDN) it renders as
+readable source text rather than a blank frame.
 
 ```html
 <section id="sec-diagram" style="margin-top:var(--s8);scroll-margin-top:var(--s7)">
   <div style="font-size:11px;font-weight:600;letter-spacing:.16em;text-transform:uppercase;color:var(--fg-faint);margin-bottom:var(--s4)"><span style="font-family:var(--mono);color:var(--accent)">03</span> &nbsp;Diagram</div>
   <figure style="margin:0">
-    <div style="border:1px solid var(--border);border-radius:var(--r3);background:var(--bg-elev);box-shadow:var(--shadow);padding:var(--s8) var(--s6);display:flex;align-items:center;justify-content:center">
-      <!-- embed the generated Mermaid SVG/markup here -->
+    <div style="border:1px solid var(--border);border-radius:var(--r3);background:var(--bg-elev);box-shadow:var(--shadow);padding:var(--s8) var(--s6);overflow:auto">
+      <!-- Diagram source AND offline fallback. Mermaid (if loaded) replaces this with an
+           SVG that the §1 `.mermaid svg` rule sizes to the frame. Quote every label. -->
+      <pre class="mermaid" style="margin:0;font-family:var(--mono);font-size:12px;color:var(--fg-muted)">
+flowchart LR
+  A["session.ts"] -->|"reads token"| B["tokenStore.get()"]
+  B --> C["middleware/authGuard"]
+      </pre>
     </div>
     <figcaption style="margin-top:var(--s3);font-size:12px;color:var(--fg-muted)">Fig 1 · one-line caption.</figcaption>
   </figure>
 </section>
+```
+
+**Label-safety (hand-authored Mermaid).** Mermaid's label grammar is unforgiving; a faithful
+copy that ignores it ships a parse-error box instead of a diagram. When you write source by
+hand:
+
+- **Quote every node and edge label** — `A["text"]`, `A -->|"text"| B`. Quoting neutralizes
+  the characters below.
+- **Never leave raw `[ ] # ( ) { }` inside an *unquoted* label.** `[`/`]` are read as
+  node-shape syntax; a bare `#` begins an HTML entity code (so `#23` breaks — write
+  `"slice 23"`); `(` opens a round-node. Quote the label or rephrase.
+- **No literal `<br/>` inside an unquoted label** — wrap the label in quotes first.
+- **For any non-trivial diagram, author it via `/mermaid`** instead of hand-writing source.
+  `/mermaid` has its own render-verification step (#94), so it catches these before the
+  source reaches the artifact — the safer path the render-confirm gate (core §7) points at.
+
+**Frame-filling render (enhancement-only; CDN per §6).** The `.mermaid svg` CSS rule already
+sizes the diagram offline-first. When the Mermaid CDN is available, initialize it with
+`flowchart.useMaxWidth:false` and run a post-render pass so the SVG fills the frame rather
+than rendering at its intrinsic (tiny) size. This is enhancement-only — it must never replace
+the `<pre class="mermaid">` source-text fallback above:
+
+```html
+<!-- enhancement-only: omit and the diagram still reads as source text offline (§6) -->
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, flowchart: { useMaxWidth: false } });
+  addEventListener('load', () => document.querySelectorAll('.mermaid svg').forEach(svg => {
+    svg.removeAttribute('width'); svg.removeAttribute('height');   // drop intrinsic sizing;
+    svg.style.width = '100%'; svg.style.height = 'auto';           // let §1's rule fill the frame
+  }));
+</script>
 ```
 
 ---

--- a/walk-commits/references/visual-rendering-core.md
+++ b/walk-commits/references/visual-rendering-core.md
@@ -143,6 +143,7 @@ The diff and its callouts are the data; everything else recedes.
 - **Small multiples + constancy of design** for before/after and per-file panels: identical scale, identical frame on both sides, so the eye reads the *difference*, not a layout change. Never restyle the after-side relative to the before-side.
 - **Subtraction of weight (1 + 1 = 3).** Adjacent heavy borders create phantom third shapes that read as content. Prefer whitespace and a single light rule to separate panels; delete every border that is not doing work.
 - **Value-scale semantic color, checked for simultaneous contrast in both themes.** Add/remove and risk colors must hold their meaning and contrast on light *and* GitHub-dark backgrounds — flip the palette on `[data-theme]`, and verify red/green stay legible against each other and the background (the principled answer to the #94 dark-mode contrast concern: a value scale, not a one-off patch).
+- **A diagram fills its frame.** Never render an embedded Mermaid SVG at its intrinsic size; size it to the column width (CSS-first, offline-safe — `.mermaid svg{width:100%;height:auto}`, per the `visual-recap-design.md` §1/§5 skeleton). A tiny centered diagram starves the data-ink the section exists to show.
 - **Respect the reading budget** (Cohen / Rigby: ~100–300 LOC, 30–60 min, <400–500 LOC/hr). The recap is *author preparation*, so it must itself stay inside the budget: **3–8 key-change callouts, focused excerpts, not every hunk.** A recap that reproduces the whole diff has rebuilt the thing the reviewer was already going to scroll. If the change is too big for one budget, say so and recommend chunking — do not render a wall.
 
 ---
@@ -158,6 +159,15 @@ The artifact must read *identically* with no network. Proven by spike: a real re
 ---
 
 ## 7. Open / serve guidance the skill should emit
+
+**Confirm an embedded diagram renders before presenting (DO-CONFIRM).** If the recap embeds a
+Mermaid diagram, verify it renders without a parse error before handing the artifact to the
+reviewer — a quick load, or a re-check against the `visual-recap-design.md` §5 label-safety
+rules. The `<pre class="mermaid">` source fallback is *not* a substitute: it shows the source
+text, which is exactly what fails to parse. This is a lightweight verification, not a build
+dependency — it must not mandate a headless browser or erode the offline-first ethos (§6).
+For any non-trivial diagram, authoring it via `/mermaid` (which verifies its own render, #94)
+discharges this check up front.
 
 `file://` is a secure context in real browsers, so the simplest path is:
 


### PR DESCRIPTION
## Summary

The canonical `/visual-recap` design skeleton (`docs/visual-recap-design.md` §5) is the template every recap copies from, so any defect *in* the skeleton is reproduced by construction in every faithful copy. Two sibling field incidents both traced to the same §5 diagram block:

- **#128** — a *valid* embedded Mermaid diagram rendered at its tiny *intrinsic* size, because §5 hard-coded a flex-centered container with no SVG sizing and no `useMaxWidth` guidance.
- **#129** — a diagram could *fail to parse entirely* (raw `[ ] # (` in unquoted labels) and reach the reviewer as an error box, because the §5 example hand-authored Mermaid with no label-escaping guidance and nothing confirmed it rendered before presenting.

Both fixes touch the same §5 block, so per the issue cross-link guidance they land in one edit pass.

**#128 — sizing (CSS-first, offline-safe):**
- §1 token core: add `.mermaid svg{width:100%;max-width:100%;height:auto;display:block}` — this rule alone fixes the too-small diagram, even offline.
- §5 container: drop `display:flex;align-items:center;justify-content:center` → full-width block with `overflow:auto`.
- §5: append an **enhancement-only** Mermaid init (`flowchart.useMaxWidth:false` + a post-render scale pass), with the `<pre class="mermaid">` source fallback preserved.
- `docs/visual-rendering-core.md` §5 quality bar: add the stated rule **"A diagram fills its frame."**

**#129 — label-safety + render-confirm:**
- §5: add a label-safety note (quote every label; no raw shape chars in unquoted labels; route non-trivial diagrams through `/mermaid`, which verifies its own render, #94).
- `docs/visual-rendering-core.md` §7 + `visual-recap/SKILL.md` Step 5: add a lightweight **DO-CONFIRM** render-confirm line before the open commands — phrased as verification, not a build dependency (preserves the §6 offline-first invariant).

The fix is paid once at the skeleton and benefits `/visual-recap`, `/walk-commits`, and the future `/visual-plan`. Ran `scripts/sync-skill-references.sh`; the four bundled copies under `visual-recap/references/` and `walk-commits/references/` regenerated (`--check` passes).

Closes #128
Closes #129