### PR TITLE
tdd + pre-merge Dim 6: give fact-emitting heuristics a failure-direction owner (#133)

### DIFF
--- a/pre-merge/review-checklist.md
+++ b/pre-merge/review-checklist.md
@@ -116,8 +116,9 @@ This is a **reconciliation test, not a gate.** Block only on unmapped Musts. War
 - Asserting call counts or call order for managed dependencies (non-boundary collaborators)
 - Opaque test data — magic numbers or unclear fixtures where evident data would make the test self-documenting
 - Implementation-coupled test names — names that describe HOW ("calls database twice") instead of WHAT ("user can checkout with valid cart")
+- Fact-emitting heuristic with an untested failure direction — the diff adds or changes a module that reduces input to a boolean/category and whose output is consumed downstream as *trusted ground truth* (most sharply, a mechanical layer feeding an LLM judge in a hybrid mechanical-then-LLM dimension), and its tests cover only the happy direction. Confirm both directions are tested: an input that must **not** trigger the fact (over-claim guard) and one that **should** in a non-obvious form (under-claim guard). **Severity asymmetry** (Nygard fault→error→failure — a wrong fact becomes an error the moment the consumer trusts it): an untested **over-claim** path is a **Concern**; an untested **under-claim** path is a **Suggestion**. Cite the specific untested input class (e.g. "a `User-agent`-scoped block read as block-all"), not "needs more tests." **Review-cadence note.** Added from one triggering incident (mimir SEO mechanical layer — three failure-direction defects shipped green, 2026-06-23) plus principle grounds (Cohen phase-injection economics, Nygard fault→error→failure). If after a reasonable sample of PRs this bullet fires <10% of the time on diffs that had no other reported issue, remove it rather than leave it as ceremony.
 
-**Out of scope:** Test coverage percentage, whether enough tests exist, whether tests pass (pre-commit hooks verify this).
+**Out of scope:** Test coverage percentage and whether enough tests exist *in general*, whether tests pass (pre-commit hooks and `/qa` own these) — **except** the fact-emitting-heuristic failure-direction case above, whose missing test points at a latent contract defect rather than a coverage gap.
 
 ---
 

--- a/tdd/tests.md
+++ b/tdd/tests.md
@@ -64,6 +64,32 @@ test("calculates order total with tax", () => {
 
 If there is no conceptual difference between two values, use the simpler one. A test checking email lowercasing needs `"ALICE@TEST.COM"`, not a realistic 40-character address.
 
+## Cover Both Failure Directions
+
+When a function reduces messy input to a boolean or category — a *classifier* that emits a **fact** ("robots.txt blocks all crawlers," "this page is covered by the sitemap," "this link is broken") — "test through the public interface" is satisfied by a single happy-direction test, and that is not enough. A classifier breaks in the *failure* direction: a `User-agent: BadBot` / `Disallow: /` group read as "blocks *all* crawlers," a trailing-slash URL read as "not covered," a third-party 403 read as "broken." The red phase must include **both** guards before you write the implementation:
+
+- **False-positive guard** — an input that looks like it should trigger the fact but must **not**.
+- **False-negative guard** — an input that **should** trigger the fact but in a non-obvious form.
+
+```typescript
+// Happy direction only — passes, but the failure direction is unguarded
+test("detects robots.txt blocking all crawlers", () => {
+  expect(blocksAllCrawlers("User-agent: *\nDisallow: /")).toBe(true);
+});
+
+// False-positive guard — a different bot is blocked, * stays permissive
+test("does not report block-all when only a non-* agent is blocked", () => {
+  expect(blocksAllCrawlers("User-agent: BadBot\nDisallow: /")).toBe(false);
+});
+
+// False-negative guard — the fact must still fire in a non-obvious form
+test("treats trailing-slash drift as covered", () => {
+  expect(coveredBySitemap("https://x.com/page", ["https://x.com/page/"])).toBe(true);
+});
+```
+
+**High-stakes case — the fact feeds a consumer that trusts it.** When the emitted fact is handed downstream as *ground truth* — most sharply, an LLM judge that treats a mechanical layer's output as trusted facts it will not re-derive — a *wrong* fact is worse than a *missing* one: it actively misleads rather than merely omits. Write the over-claim (false-positive) guard first; it is the path that turns a fault into an error the moment the consumer trusts the fact.
+
 ```typescript
 // BAD: Bypasses interface to verify
 test("createUser saves to database", async () => {


### PR DESCRIPTION
## Summary

Skill Kit had a blind spot at both ends of the pipeline for a specific bug class: a *classifier* — a function that reduces messy input to a boolean/category fact ("robots.txt blocks all crawlers," "this page is covered by the sitemap") — whose **failure direction** is untested. A single happy-path test satisfies "test through the public interface," so the over-claim/under-claim paths ship green. The class is especially dangerous in the hybrid mechanical-then-LLM pattern, where the fact is fed to an LLM judge as trusted ground truth: a *wrong* fact actively misleads the model, whereas a *missing* one merely omits. The triggering incident (mimir's SEO mechanical layer) shipped three such defects past 22 green tests; a human caught all three.

This PR implements the Mediator's "minimal coherent change set" from #133 — defense-in-depth across construction and review:

- **`tdd/tests.md`** (prevention, primary) — new **"Cover Both Failure Directions"** section. For a classifier, the red phase must include a false-positive guard and a non-obvious false-negative guard *before* implementation, with three worked examples and the high-stakes LLM-ground-truth callout.
- **`pre-merge/review-checklist.md` Dim 6** (detection, backstop) — new violation bullet gated to modules consumed as trusted ground truth, with a Nygard fault→error→failure severity asymmetry (untested over-claim = Concern, under-claim = Suggestion); an Out-of-scope carve-out distinguishing this contract defect from a coverage-% gap; and a review-cadence note with the same `<10%` falsification rule as Dims 8/10/11.

The dimension count stays at **11** (no `pre-merge/SKILL.md` sync); the `/qa` boundary holds (the finding is *test-adequacy of a contract*, not bug-hunting). `/write-a-prd` and `/prd-to-issues` changes were deferred per the issue's Non-Goals.

## PRD

Closes #133

## Key Decisions

- New `/pre-merge` guidance is a **bullet under Dimension 6**, not a 12th dimension — keeps the "11 dimensions" count stable and avoids the multi-reference SKILL.md sync.
- The Out-of-scope line is **amended with a carve-out**, not rewritten, so it still disclaims coverage-% in general while admitting the one contract-defect-shaped case.
